### PR TITLE
Don't change empty responses to 'None'

### DIFF
--- a/elastic_transport/_async_transport.py
+++ b/elastic_transport/_async_transport.py
@@ -281,7 +281,7 @@ class AsyncTransport(Transport):
                     )
                 )
 
-                if raw_data not in (None, b""):
+                if method != "HEAD":
                     data = self.serializers.loads(raw_data, meta.mimetype)
                 else:
                     data = None

--- a/elastic_transport/_node/_http_requests.py
+++ b/elastic_transport/_node/_http_requests.py
@@ -172,7 +172,7 @@ class RequestsHttpNode(BaseNode):
             )
         )
         try:
-            response = self.session.send(prepared_request, **send_kwargs)
+            response = self.session.send(prepared_request, **send_kwargs)  # type: ignore[arg-type]
             data = response.content
             duration = time.time() - start
             response_headers = HttpHeaders(response.headers)

--- a/elastic_transport/_transport.py
+++ b/elastic_transport/_transport.py
@@ -338,7 +338,7 @@ class Transport:
                     )
                 )
 
-                if raw_data not in (None, b""):
+                if method != "HEAD":
                     data = self.serializers.loads(raw_data, meta.mimetype)
                 else:
                     data = None

--- a/elastic_transport/client_utils.py
+++ b/elastic_transport/client_utils.py
@@ -156,7 +156,7 @@ _QUOTE_ALWAYS_SAFE = frozenset(
 
 
 def percent_encode(
-    string: str,
+    string: Union[bytes, str],
     safe: str = "/",
     encoding: Optional[str] = None,
     errors: Optional[str] = None,
@@ -165,7 +165,7 @@ def percent_encode(
     # Redefines 'urllib.parse.quote()' to always have the '~' character
     # within the 'ALWAYS_SAFE' list. The character was added in Python 3.7
     safe = "".join(_QUOTE_ALWAYS_SAFE.union(set(safe)))
-    return _quote(string, safe, encoding=encoding, errors=errors)
+    return _quote(string, safe, encoding=encoding, errors=errors)  # type: ignore[arg-type]
 
 
 def basic_auth_to_header(basic_auth: Tuple[str, str]) -> str:


### PR DESCRIPTION
Found this issue when using `cat` APIs that returned an empty string which shouldn't be shunted to `None`, instead should be `""`. We really only want to do this for `HEAD` requests.