### PR TITLE
Remove 'furo' from Sphinx extensions

### DIFF
--- a/docs/sphinx/conf.py
+++ b/docs/sphinx/conf.py
@@ -32,7 +32,6 @@ release = __version__
 extensions = [
     "sphinx.ext.autodoc",
     "sphinx.ext.intersphinx",
-    "furo",
     "sphinx_autodoc_typehints",
 ]
 


### PR DESCRIPTION
Furo doesn't like being listed in `extensions` so we remove it.

See: https://github.com/pradyunsg/furo/commit/4fbb7a92306c2107ba3400d333046613285b6659