### PR TITLE
Change 'ApiError' base class to 'Exception'

### DIFF
--- a/elastic_transport/_exceptions.py
+++ b/elastic_transport/_exceptions.py
@@ -91,7 +91,7 @@ class ConnectionTimeout(TransportError):
         return "Connection timed out"
 
 
-class ApiError(TransportError):
+class ApiError(Exception):
     """Base-class for clients that raise errors due to a response such as '404 Not Found'"""
 
     def __init__(
@@ -101,7 +101,9 @@ class ApiError(TransportError):
         body: Any,
         errors: Tuple[Exception, ...] = (),
     ):
-        super().__init__(message=message, errors=errors)
+        super().__init__(message)
+        self.message = message
+        self.errors = errors
         self.meta = meta
         self.body = body
 

--- a/elastic_transport/_node/_http_requests.py
+++ b/elastic_transport/_node/_http_requests.py
@@ -73,7 +73,6 @@ try:
             super().init_poolmanager(connections, maxsize, block=block, **pool_kwargs)  # type: ignore [no-untyped-call]
             self.poolmanager.pool_classes_by_scheme["https"] = HTTPSConnectionPool
 
-
 except ImportError:  # pragma: nocover
     _REQUESTS_AVAILABLE = False
     _REQUESTS_META_VERSION = ""

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -15,6 +15,8 @@
 #  specific language governing permissions and limitations
 #  under the License.
 
+import pytest
+
 from elastic_transport import ApiError, ApiResponseMeta, TransportError
 
 
@@ -43,3 +45,21 @@ def test_api_error_status_repr():
         == "ApiError({'errors': [{'status': 500}]}, meta=ApiResponseMeta(status=500, http_version='1.1', headers={}, duration=0.0, node=None), body={})"
     )
     assert str(e) == "[500] {'errors': [{'status': 500}]}"
+
+
+def test_api_error_is_not_transport_error():
+    with pytest.raises(ApiError):
+        try:
+            raise ApiError("", None, None)
+        except TransportError:
+            pass
+
+
+def test_transport_error_is_not_api_error():
+    with pytest.raises(TransportError):
+        try:
+            raise TransportError(
+                "",
+            )
+        except ApiError:
+            pass


### PR DESCRIPTION
This means that client code can either catch `ApiError` or `TransportError` without worrying about overlapping.