### PR TITLE
Fix aiohttp.__version__ splitting logic

### DIFF
--- a/elastic_transport/_node/_http_aiohttp.py
+++ b/elastic_transport/_node/_http_aiohttp.py
@@ -20,6 +20,7 @@ import base64
 import functools
 import gzip
 import os
+import re
 import ssl
 import warnings
 from typing import Optional, Tuple, Union
@@ -42,7 +43,14 @@ try:
 
     _AIOHTTP_AVAILABLE = True
     _AIOHTTP_META_VERSION = client_meta_version(aiohttp.__version__)
-    _AIOHTTP_SEMVER_VERSION = tuple(int(x) for x in aiohttp.__version__.split(".")[:3])
+
+    _version_parts = []
+    for _version_part in aiohttp.__version__.split(".")[:3]:
+        try:
+            _version_parts.append(int(re.search(r"^([0-9]+)", _version_part).group(1)))  # type: ignore[union-attr]
+        except (AttributeError, ValueError):
+            break
+    _AIOHTTP_SEMVER_VERSION = tuple(_version_parts)
 
     # See aio-libs/aiohttp#1769 and #5012
     _AIOHTTP_FIXED_HEAD_BUG = _AIOHTTP_SEMVER_VERSION >= (3, 7, 0)

--- a/elastic_transport/_node/_http_requests.py
+++ b/elastic_transport/_node/_http_requests.py
@@ -21,7 +21,7 @@ import time
 import warnings
 from typing import Any, Optional, Tuple, Union
 
-import urllib3  # type: ignore[import]
+import urllib3
 
 from .._compat import warn_stacklevel
 from .._exceptions import ConnectionError, ConnectionTimeout, SecurityWarning, TlsError
@@ -46,7 +46,7 @@ try:
     try:
         from ._urllib3_chain_certs import HTTPSConnectionPool
     except (ImportError, AttributeError):
-        HTTPSConnectionPool = urllib3.HTTPSConnectionPool  # type: ignore[misc]
+        HTTPSConnectionPool = urllib3.HTTPSConnectionPool  # type: ignore[assignment,misc]
 
     class _ElasticHTTPAdapter(HTTPAdapter):
         def __init__(self, node_config: NodeConfig, **kwargs: Any) -> None:
@@ -124,7 +124,7 @@ class RequestsHttpNode(BaseNode):
             self.session.verify = config.ca_certs
 
         if not config.ssl_show_warn:
-            urllib3.disable_warnings()
+            urllib3.disable_warnings()  # type: ignore[no-untyped-call]
 
         if (
             config.scheme == "https"

--- a/elastic_transport/_node/_http_urllib3.py
+++ b/elastic_transport/_node/_http_urllib3.py
@@ -21,13 +21,9 @@ import time
 import warnings
 from typing import Any, Dict, Optional, Tuple, Union
 
-import urllib3  # type: ignore[import]
-from urllib3.exceptions import (  # type: ignore[import]
-    ConnectTimeoutError,
-    NewConnectionError,
-    ReadTimeoutError,
-)
-from urllib3.util.retry import Retry  # type: ignore[import]
+import urllib3
+from urllib3.exceptions import ConnectTimeoutError, NewConnectionError, ReadTimeoutError
+from urllib3.util.retry import Retry
 
 from .._compat import warn_stacklevel
 from .._exceptions import ConnectionError, ConnectionTimeout, SecurityWarning, TlsError
@@ -44,7 +40,7 @@ from ._base import (
 try:
     from ._urllib3_chain_certs import HTTPSConnectionPool
 except (ImportError, AttributeError):
-    HTTPSConnectionPool = urllib3.HTTPSConnectionPool  # type: ignore[misc]
+    HTTPSConnectionPool = urllib3.HTTPSConnectionPool  # type: ignore[assignment,misc]
 
 
 class Urllib3HttpNode(BaseNode):
@@ -99,7 +95,7 @@ class Urllib3HttpNode(BaseNode):
                         category=SecurityWarning,
                     )
                 else:
-                    urllib3.disable_warnings()
+                    urllib3.disable_warnings()  # type: ignore[no-untyped-call]
 
         self.pool = pool_class(
             config.host,
@@ -139,7 +135,7 @@ class Urllib3HttpNode(BaseNode):
             else:
                 body_to_send = None
 
-            response = self.pool.urlopen(
+            response = self.pool.urlopen(  # type: ignore[no-untyped-call]
                 method,
                 target,
                 body=body_to_send,
@@ -200,4 +196,4 @@ class Urllib3HttpNode(BaseNode):
         """
         Explicitly closes connection
         """
-        self.pool.close()
+        self.pool.close()  # type: ignore[no-untyped-call]

--- a/elastic_transport/_node/_urllib3_chain_certs.py
+++ b/elastic_transport/_node/_urllib3_chain_certs.py
@@ -22,8 +22,8 @@ from hmac import compare_digest
 from typing import Any, List, Optional
 
 import _ssl  # type: ignore
-import urllib3  # type: ignore[import]
-import urllib3.connection  # type: ignore[import]
+import urllib3
+import urllib3.connection
 
 from ._base import RERAISE_EXCEPTIONS
 
@@ -36,7 +36,7 @@ _HASHES_BY_LENGTH = {32: hashlib.md5, 40: hashlib.sha1, 64: hashlib.sha256}
 __all__ = ["HTTPSConnectionPool"]
 
 
-class HTTPSConnectionPool(urllib3.HTTPSConnectionPool):  # type: ignore[misc]
+class HTTPSConnectionPool(urllib3.HTTPSConnectionPool):
     """HTTPSConnectionPool implementation which supports ``assert_fingerprint``
     on certificates within the chain instead of only the leaf cert using private
     APIs in CPython 3.10+
@@ -71,7 +71,7 @@ class HTTPSConnectionPool(urllib3.HTTPSConnectionPool):  # type: ignore[misc]
         """
         Called right before a request is made, after the socket is created.
         """
-        super(HTTPSConnectionPool, self)._validate_conn(conn)
+        super(HTTPSConnectionPool, self)._validate_conn(conn)  # type: ignore[misc]
 
         if self._elastic_assert_fingerprint:
             hash_func = _HASHES_BY_LENGTH[len(self._elastic_assert_fingerprint)]

--- a/elastic_transport/client_utils.py
+++ b/elastic_transport/client_utils.py
@@ -23,8 +23,8 @@ from platform import python_version
 from typing import Optional, Tuple, TypeVar, Union
 from urllib.parse import quote as _quote
 
-from urllib3.exceptions import LocationParseError  # type: ignore[import]
-from urllib3.util import parse_url  # type: ignore[import]
+from urllib3.exceptions import LocationParseError
+from urllib3.util import parse_url
 
 from ._models import DEFAULT, DefaultType, NodeConfig
 from ._utils import fixup_module_metadata
@@ -187,7 +187,7 @@ def url_to_node_config(url: str) -> NodeConfig:
     'Authorization' header.
     """
     try:
-        parsed_url = parse_url(url)
+        parsed_url = parse_url(url)  # type: ignore[no-untyped-call]
     except LocationParseError:
         raise ValueError(f"Could not parse URL {url!r}") from None
 


### PR DESCRIPTION
When installing pre-releases the blind call to `int()` would fail on the final version part.