### PR TITLE
Set enable_cleanup_closed=True to drop TLS connections without a shutdown

### DIFF
--- a/elastic_transport/_node/_http_aiohttp.py
+++ b/elastic_transport/_node/_http_aiohttp.py
@@ -258,6 +258,7 @@ class AiohttpHttpNode(BaseAsyncNode):
             connector=aiohttp.TCPConnector(
                 limit_per_host=self._connections_per_node,
                 use_dns_cache=True,
+                enable_cleanup_closed=True,
                 ssl=self._ssl_context,
             ),
         )


### PR DESCRIPTION
See: https://github.com/elastic/elasticsearch-py/issues/1910