### PR TITLE
Honor 'path_prefix' on Urllib3HttpNode

### DIFF
--- a/elastic_transport/_node/_http_urllib3.py
+++ b/elastic_transport/_node/_http_urllib3.py
@@ -116,6 +116,9 @@ class Urllib3HttpNode(BaseNode):
         request_timeout: Union[DefaultType, Optional[float]] = DEFAULT,
     ) -> NodeApiResponse:
 
+        if self.path_prefix:
+            target = f"{self.path_prefix}{target}"
+
         start = time.time()
         try:
             kw = {}

--- a/tests/node/test_http_urllib3.py
+++ b/tests/node/test_http_urllib3.py
@@ -78,6 +78,24 @@ class TestUrllib3HttpNode:
         assert "accept-encoding" not in kwargs["headers"]
         assert "content-encoding" not in kwargs["headers"]
 
+    @pytest.mark.parametrize(
+        ["request_target", "expected_target"],
+        [
+            ("/_search", "/prefix/_search"),
+            ("/?key=val", "/prefix/?key=val"),
+            ("/_search?key=val/", "/prefix/_search?key=val/"),
+        ],
+    )
+    def test_path_prefix_applied_to_target(self, request_target, expected_target):
+        node = self._get_mock_node(
+            NodeConfig("http", "localhost", 80, path_prefix="/prefix")
+        )
+
+        node.perform_request("GET", request_target)
+        (_, target), _ = node.pool.urlopen.call_args
+
+        assert target == expected_target
+
     @pytest.mark.parametrize("empty_body", [None, b""])
     def test_http_compression(self, empty_body):
         node = self._get_mock_node(


### PR DESCRIPTION
Closes https://github.com/elastic/elastic-transport-python/issues/64