### PR TITLE
Fix HTTPS connection when host is an IP address

### DIFF
--- a/elastic_transport/_node/_base.py
+++ b/elastic_transport/_node/_base.py
@@ -22,6 +22,7 @@ import ssl
 from typing import Any, ClassVar, List, NamedTuple, Optional, Tuple, Union
 
 from .._models import ApiResponseMeta, HttpHeaders, NodeConfig
+from .._utils import is_ipaddress
 from .._version import __version__
 from ..client_utils import DEFAULT, DefaultType
 
@@ -295,7 +296,7 @@ def ssl_context_from_node_config(node_config: NodeConfig) -> ssl.SSLContext:
         # step if the user doesn't pass a preconfigured SSLContext.
         if node_config.verify_certs:
             ctx.verify_mode = ssl.CERT_REQUIRED
-            ctx.check_hostname = True
+            ctx.check_hostname = not is_ipaddress(node_config.host)
         else:
             ctx.check_hostname = False
             ctx.verify_mode = ssl.CERT_NONE

--- a/elastic_transport/_utils.py
+++ b/elastic_transport/_utils.py
@@ -15,7 +15,8 @@
 #  specific language governing permissions and limitations
 #  under the License.
 
-from typing import Any, Dict
+import re
+from typing import Any, Dict, Union
 
 
 def fixup_module_metadata(module_name: str, namespace: Dict[str, Any]) -> None:
@@ -31,3 +32,48 @@ def fixup_module_metadata(module_name: str, namespace: Dict[str, Any]) -> None:
     for objname in namespace["__all__"]:
         obj = namespace[objname]
         fix_one(obj)
+
+
+IPV4_PAT = r"(?:[0-9]{1,3}\.){3}[0-9]{1,3}"
+IPV4_RE = re.compile("^" + IPV4_PAT + "$")
+
+HEX_PAT = "[0-9A-Fa-f]{1,4}"
+LS32_PAT = "(?:{hex}:{hex}|{ipv4})".format(hex=HEX_PAT, ipv4=IPV4_PAT)
+_subs = {"hex": HEX_PAT, "ls32": LS32_PAT}
+_variations = [
+    #                            6( h16 ":" ) ls32
+    "(?:%(hex)s:){6}%(ls32)s",
+    #                       "::" 5( h16 ":" ) ls32
+    "::(?:%(hex)s:){5}%(ls32)s",
+    # [               h16 ] "::" 4( h16 ":" ) ls32
+    "(?:%(hex)s)?::(?:%(hex)s:){4}%(ls32)s",
+    # [ *1( h16 ":" ) h16 ] "::" 3( h16 ":" ) ls32
+    "(?:(?:%(hex)s:)?%(hex)s)?::(?:%(hex)s:){3}%(ls32)s",
+    # [ *2( h16 ":" ) h16 ] "::" 2( h16 ":" ) ls32
+    "(?:(?:%(hex)s:){0,2}%(hex)s)?::(?:%(hex)s:){2}%(ls32)s",
+    # [ *3( h16 ":" ) h16 ] "::"    h16 ":"   ls32
+    "(?:(?:%(hex)s:){0,3}%(hex)s)?::%(hex)s:%(ls32)s",
+    # [ *4( h16 ":" ) h16 ] "::"              ls32
+    "(?:(?:%(hex)s:){0,4}%(hex)s)?::%(ls32)s",
+    # [ *5( h16 ":" ) h16 ] "::"              h16
+    "(?:(?:%(hex)s:){0,5}%(hex)s)?::%(hex)s",
+    # [ *6( h16 ":" ) h16 ] "::"
+    "(?:(?:%(hex)s:){0,6}%(hex)s)?::",
+]
+IPV6_PAT = "(?:" + "|".join([x % _subs for x in _variations]) + ")"
+UNRESERVED_PAT = r"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789._!\-~"
+ZONE_ID_PAT = "(?:%25|%)(?:[" + UNRESERVED_PAT + "]|%[a-fA-F0-9]{2})+"
+BRACELESS_IPV6_ADDRZ_PAT = IPV6_PAT + r"(?:" + ZONE_ID_PAT + r")?"
+BRACELESS_IPV6_ADDRZ_RE = re.compile("^" + BRACELESS_IPV6_ADDRZ_PAT + "$")
+
+
+def is_ipaddress(hostname: Union[str, bytes]) -> bool:
+    """Detects whether the hostname given is an IPv4 or IPv6 address.
+    Also detects IPv6 addresses with Zone IDs.
+    """
+    # Copied from urllib3. License: MIT
+    if isinstance(hostname, bytes):
+        # IDN A-label bytes are ASCII compatible.
+        hostname = hostname.decode("ascii")
+    hostname = hostname.strip("[]")
+    return bool(IPV4_RE.match(hostname) or BRACELESS_IPV6_ADDRZ_RE.match(hostname))

--- a/setup.py
+++ b/setup.py
@@ -61,6 +61,8 @@ setup(
             "pytest-cov",
             "pytest-mock",
             "pytest-asyncio",
+            "pytest-httpserver",
+            "trustme",
             "mock",
             "requests",
             "aiohttp",

--- a/tests/async_/test_httpserver.py
+++ b/tests/async_/test_httpserver.py
@@ -1,0 +1,35 @@
+#  Licensed to Elasticsearch B.V. under one or more contributor
+#  license agreements. See the NOTICE file distributed with
+#  this work for additional information regarding copyright
+#  ownership. Elasticsearch B.V. licenses this file to you under
+#  the Apache License, Version 2.0 (the "License"); you may
+#  not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+# 	http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing,
+#  software distributed under the License is distributed on an
+#  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+#  KIND, either express or implied.  See the License for the
+#  specific language governing permissions and limitations
+#  under the License.
+
+import warnings
+
+import pytest
+
+from elastic_transport import AsyncTransport
+
+pytestmark = pytest.mark.asyncio
+
+
+async def test_simple_request(https_server_ip_node_config):
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+
+        t = AsyncTransport([https_server_ip_node_config])
+
+        resp, data = await t.perform_request("GET", "/foobar")
+        assert resp.status == 200
+        assert data == {"foo": "bar"}

--- a/tests/test_httpserver.py
+++ b/tests/test_httpserver.py
@@ -1,0 +1,34 @@
+#  Licensed to Elasticsearch B.V. under one or more contributor
+#  license agreements. See the NOTICE file distributed with
+#  this work for additional information regarding copyright
+#  ownership. Elasticsearch B.V. licenses this file to you under
+#  the Apache License, Version 2.0 (the "License"); you may
+#  not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+# 	http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing,
+#  software distributed under the License is distributed on an
+#  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+#  KIND, either express or implied.  See the License for the
+#  specific language governing permissions and limitations
+#  under the License.
+
+import warnings
+
+import pytest
+
+from elastic_transport import Transport
+
+
+@pytest.mark.parametrize("node_class", ["urllib3", "requests"])
+def test_simple_request(node_class, https_server_ip_node_config):
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+
+        t = Transport([https_server_ip_node_config], node_class=node_class)
+
+        resp, data = t.perform_request("GET", "/foobar")
+        assert resp.status == 200
+        assert data == {"foo": "bar"}

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -17,32 +17,39 @@
 
 import pytest
 
-from elastic_transport import (
-    AiohttpHttpNode,
-    NodeConfig,
-    RequestsHttpNode,
-    Urllib3HttpNode,
-)
-from elastic_transport._node._base import ssl_context_from_node_config
+from elastic_transport._utils import is_ipaddress
 
 
 @pytest.mark.parametrize(
-    "node_cls", [Urllib3HttpNode, RequestsHttpNode, AiohttpHttpNode]
-)
-def test_unknown_parameter(node_cls):
-    with pytest.raises(TypeError):
-        node_cls(unknown_option=1)
-
-
-@pytest.mark.parametrize(
-    "host, check_hostname",
+    "addr",
     [
-        ("127.0.0.1", False),
-        ("::1", False),
-        ("localhost", True),
+        # IPv6
+        "::1",
+        "::",
+        "FE80::8939:7684:D84b:a5A4%251",
+        # IPv4
+        "127.0.0.1",
+        "8.8.8.8",
+        b"127.0.0.1",
+        # IPv6 w/ Zone IDs
+        "FE80::8939:7684:D84b:a5A4%251",
+        b"FE80::8939:7684:D84b:a5A4%251",
+        "FE80::8939:7684:D84b:a5A4%19",
+        b"FE80::8939:7684:D84b:a5A4%19",
     ],
 )
-def test_ssl_context_from_node_config(host, check_hostname):
-    node_config = NodeConfig("https", host, 443)
-    ctx = ssl_context_from_node_config(node_config)
-    assert ctx.check_hostname == check_hostname
+def test_is_ipaddress(addr):
+    assert is_ipaddress(addr)
+
+
+@pytest.mark.parametrize(
+    "addr",
+    [
+        "www.python.org",
+        b"www.python.org",
+        "v2.sg.media-imdb.com",
+        b"v2.sg.media-imdb.com",
+    ],
+)
+def test_is_not_ipaddress(addr):
+    assert not is_ipaddress(addr)


### PR DESCRIPTION
Closes https://github.com/elastic/elasticsearch-py/issues/1958

While it looks like it might be possible to use an IP address in a certificate, I've never seen it used and it's explicitly forbidden for SNI (RFC 3546, Section 3.1). Additionally, `server_hostname` is not set in urllib3 when the host is an IP, which raises an exception in the ssl standard module.

The main majority of the new code comes from urllib3. I could have used `urllib3.util.ssl_.is_ip_address` directly but thought that was rude!