### PR TITLE
Allow clients to use default ports for URL scheme

### DIFF
--- a/elastic_transport/_node/_http_requests.py
+++ b/elastic_transport/_node/_http_requests.py
@@ -132,7 +132,7 @@ class RequestsHttpNode(BaseNode):
                     self.session.verify = config.verify_certs
 
                 if not config.ssl_show_warn:
-                    urllib3.disable_warnings()  # type: ignore[no-untyped-call]
+                    urllib3.disable_warnings()
 
                 if (
                     config.scheme == "https"
@@ -210,7 +210,7 @@ class RequestsHttpNode(BaseNode):
             else self.config.request_timeout
         }
         send_kwargs.update(
-            self.session.merge_environment_settings(  # type: ignore[no-untyped-call]
+            self.session.merge_environment_settings(  # type: ignore[arg-type]
                 prepared_request.url, {}, None, None, None
             )
         )

--- a/elastic_transport/_node/_http_urllib3.py
+++ b/elastic_transport/_node/_http_urllib3.py
@@ -118,7 +118,7 @@ class Urllib3HttpNode(BaseNode):
                             category=SecurityWarning,
                         )
                     else:
-                        urllib3.disable_warnings()  # type: ignore[no-untyped-call]
+                        urllib3.disable_warnings()
 
         self.pool = pool_class(
             config.host,
@@ -222,4 +222,4 @@ class Urllib3HttpNode(BaseNode):
         """
         Explicitly closes connection
         """
-        self.pool.close()  # type: ignore[no-untyped-call]
+        self.pool.close()

--- a/elastic_transport/client_utils.py
+++ b/elastic_transport/client_utils.py
@@ -181,19 +181,31 @@ def basic_auth_to_header(basic_auth: Tuple[str, str]) -> str:
     return f"Basic {base64.b64encode((b':'.join(to_bytes(x) for x in basic_auth))).decode()}"
 
 
-def url_to_node_config(url: str) -> NodeConfig:
+def url_to_node_config(url: str, use_default_ports_for_scheme: bool=False) -> NodeConfig:
     """Constructs a :class:`elastic_transport.NodeConfig` instance from a URL.
     If a username/password are specified in the URL they are converted to an
     'Authorization' header.
+
+    :param url: URL to transform into a NodeConfig.
+    :param use_default_ports_for_scheme: If 'True' will resolve default ports for the given scheme.
     """
     try:
         parsed_url = parse_url(url)  # type: ignore[no-untyped-call]
     except LocationParseError:
         raise ValueError(f"Could not parse URL {url!r}") from None
 
+    # Only fill in a default port for HTTP and HTTPS
+    # when we know the scheme is one of those two.
+    parsed_port: Optional[int] = parsed_url.port
+    if parsed_url.port is None and parsed_url.scheme is not None and use_default_ports_for_scheme is True:
+        if parsed_url.scheme == "https":
+            parsed_port = 443
+        elif parsed_url.scheme == "http":
+            parsed_port = 80
+
     if any(
         component in (None, "")
-        for component in (parsed_url.scheme, parsed_url.host, parsed_url.port)
+        for component in (parsed_url.scheme, parsed_url.host, parsed_port)
     ):
         raise ValueError(
             "URL must include a 'scheme', 'host', and 'port' component (ie 'https://localhost:9200')"
@@ -209,7 +221,7 @@ def url_to_node_config(url: str) -> NodeConfig:
     return NodeConfig(
         scheme=parsed_url.scheme,
         host=host,
-        port=parsed_url.port,
+        port=parsed_port,
         path_prefix=path_prefix,
         headers=headers,
     )

--- a/tests/test_client_utils.py
+++ b/tests/test_client_utils.py
@@ -198,6 +198,19 @@ def test_url_to_node_config_error_missing_component(url):
     )
 
 
+@pytest.mark.parametrize(
+    ["url", "port"],
+    [
+        ("http://127.0.0.1", 80),
+        ("http://[::1]", 80),
+        ("HTTPS://localhost", 443),
+        ("https://localhost/url-prefix", 443),
+    ],
+)
+def test_url_to_node_config_use_default_ports_for_scheme(url, port):
+    node_config = url_to_node_config(url, use_default_ports_for_scheme=True)
+    assert node_config.port == port
+
 def test_url_with_auth_into_authorization():
     node_config = url_to_node_config("http://localhost:9200")
     assert node_config.headers == {}

--- a/tests/test_client_utils.py
+++ b/tests/test_client_utils.py
@@ -211,6 +211,7 @@ def test_url_to_node_config_use_default_ports_for_scheme(url, port):
     node_config = url_to_node_config(url, use_default_ports_for_scheme=True)
     assert node_config.port == port
 
+
 def test_url_with_auth_into_authorization():
     node_config = url_to_node_config("http://localhost:9200")
     assert node_config.headers == {}


### PR DESCRIPTION
Related to: https://github.com/elastic/enterprise-search-python/issues/144