### PR TITLE
Tests: Remove test url with 0 as port

### DIFF
--- a/tests/test_client_utils.py
+++ b/tests/test_client_utils.py
@@ -159,7 +159,6 @@ def test_invalid_cloud_id(cloud_id):
             "/url-prefix",
         ),
         ("http://[::1]:3002/url-prefix", "http://[::1]:3002/url-prefix", "/url-prefix"),
-        ("https://[::1]:0/", "https://[::1]:0", ""),
     ],
 )
 def test_url_to_node_config(url, node_base_url, path_prefix):


### PR DESCRIPTION
Removes the broken url test with latest urllib3 release.

The 1.26.13 urllib3 release removes all the leading zero in port parsing so the zero port is similar to do not provide the port: https://github.com/urllib3/urllib3/releases/tag/1.26.13

Fix https://github.com/elastic/elastic-transport-python/issues/96