### PR TITLE
Updated metadata to use group email address

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -37,10 +37,8 @@ setup(
     long_description=long_description,
     long_description_content_type="text/markdown",
     version=version,
-    author="Elastic",
-    author_email="support@elastic.co",
-    maintainer="Clients Team",
-    maintainer_email="clients-team@elastic.co",
+    author="Elastic Client Library Maintainers",
+    author_email="client-libs@elastic.co",
     url="https://github.com/elastic/elastic-transport-python",
     project_urls={
         "Source Code": "https://github.com/elastic/elastic-transport-python",


### PR DESCRIPTION
This PR removes individual names and email addresses and replaces those with the new (external) [group email address](mailto:client-libs@elastic.co).

The author and maintainer fields have also been collapsed down into just author. According to [setuptools](https://setuptools.pypa.io/en/latest/references/keywords.html), the maintainer is used as an override for author, so the former is removed to use only the primary field.