### PR TITLE
Prevent OverflowError on large number of retries

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,10 +42,6 @@ jobs:
         python-version: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12-dev"]
         os: ["ubuntu-latest"]
         experimental: [false]
-        include:
-          - python-version: "3.6"
-            experimental: false
-            os: ubuntu-20.04
 
     runs-on: ${{ matrix.os }}
     name: test-${{ matrix.python-version }}

--- a/elastic_transport/_node_pool.py
+++ b/elastic_transport/_node_pool.py
@@ -238,10 +238,13 @@ class NodePool:
             pass
         consecutive_failures = self._dead_consecutive_failures[node.config] + 1
         self._dead_consecutive_failures[node.config] = consecutive_failures
-        timeout = min(
-            self._dead_node_backoff_factor * (2 ** (consecutive_failures - 1)),
-            self._max_dead_node_backoff,
-        )
+        try:
+            timeout = min(
+                self._dead_node_backoff_factor * (2 ** (consecutive_failures - 1)),
+                self._max_dead_node_backoff,
+            )
+        except OverflowError:
+            timeout = self._max_dead_node_backoff
         self._dead_nodes.put((now + timeout, node))
         _logger.warning(
             "Node %r has failed for %i times in a row, putting on %i second timeout",

--- a/elastic_transport/_version.py
+++ b/elastic_transport/_version.py
@@ -15,4 +15,4 @@
 #  specific language governing permissions and limitations
 #  under the License.
 
-__version__ = "8.5.0+dev"
+__version__ = "8.5.1+dev"

--- a/elastic_transport/client_utils.py
+++ b/elastic_transport/client_utils.py
@@ -136,7 +136,7 @@ def parse_cloud_id(cloud_id: str) -> CloudId:
 def to_str(
     value: Union[str, bytes], encoding: str = "utf-8", errors: str = "strict"
 ) -> str:
-    if type(value) == bytes:
+    if isinstance(value, bytes):
         return value.decode(encoding, errors)
     return value  # type: ignore[return-value]
 
@@ -144,7 +144,7 @@ def to_str(
 def to_bytes(
     value: Union[str, bytes], encoding: str = "utf-8", errors: str = "strict"
 ) -> bytes:
-    if type(value) == str:
+    if isinstance(value, str):
         return value.encode(encoding, errors)
     return value  # type: ignore[return-value]
 

--- a/elastic_transport/client_utils.py
+++ b/elastic_transport/client_utils.py
@@ -138,7 +138,7 @@ def to_str(
 ) -> str:
     if isinstance(value, bytes):
         return value.decode(encoding, errors)
-    return value  # type: ignore[return-value]
+    return value
 
 
 def to_bytes(
@@ -146,7 +146,7 @@ def to_bytes(
 ) -> bytes:
     if isinstance(value, str):
         return value.encode(encoding, errors)
-    return value  # type: ignore[return-value]
+    return value
 
 
 # Python 3.7 added '~' to the safe list for urllib.parse.quote()

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -72,7 +72,7 @@ async def test_debug_logging(node_class, httpbin_node_config):
         "< HTTP/1.1 200 OK",
         "< Access-Control-Allow-Credentials: true",
         "< Access-Control-Allow-Origin: *",
-        "< Connection: keep-alive",
+        "< Connection: close",
         "< Content-Type: application/json",
         "< {",
         '  "args": {}, ',

--- a/tests/test_node_pool.py
+++ b/tests/test_node_pool.py
@@ -194,7 +194,7 @@ def test_dead_node_backoff_calculation():
 
     assert pool.get() is node
     pool.mark_dead(node, _now=0)
-    
+
     pool._dead_consecutive_failures = {node.config: 13292}
     assert pool._dead_nodes.queue == [(3.5, node)]
 

--- a/tests/test_node_pool.py
+++ b/tests/test_node_pool.py
@@ -193,6 +193,11 @@ def test_dead_node_backoff_calculation():
     assert pool._dead_nodes.queue == [(3.5, node)]
 
     assert pool.get() is node
+    pool._dead_consecutive_failures = {node.config: 13292}
+    pool.mark_dead(node, _now=0)
+    assert pool._dead_nodes.queue == [(3.5, node)]
+
+    assert pool.get() is node
     pool.mark_live(node)
 
     assert pool._dead_consecutive_failures == {}

--- a/tests/test_node_pool.py
+++ b/tests/test_node_pool.py
@@ -193,8 +193,9 @@ def test_dead_node_backoff_calculation():
     assert pool._dead_nodes.queue == [(3.5, node)]
 
     assert pool.get() is node
-    pool._dead_consecutive_failures = {node.config: 13292}
     pool.mark_dead(node, _now=0)
+    
+    pool._dead_consecutive_failures = {node.config: 13292}
     assert pool._dead_nodes.queue == [(3.5, node)]
 
     assert pool.get() is node


### PR DESCRIPTION
Defaults to max backoff value when consecutive failure count is high.

A fix for https://github.com/elastic/elasticsearch-py/issues/2262.
