### PR TITLE
Fix TypeError when NodePool._dead_nodes timestamps are not unique

### DIFF
--- a/elastic_transport/_node/_base.py
+++ b/elastic_transport/_node/_base.py
@@ -143,6 +143,11 @@ class BaseNode:
     def __repr__(self) -> str:
         return f"<{self.__class__.__name__}({self.base_url})>"
 
+    def __lt__(self, other: object) -> bool:
+        if not isinstance(other, BaseNode):
+            return NotImplemented
+        return id(self) < id(other)
+
     def __eq__(self, other: object) -> bool:
         if not isinstance(other, BaseNode):
             return NotImplemented


### PR DESCRIPTION
Makes node objects comparable by overriding the `<` operator on the [`BaseNode`](https://github.com/elastic/elastic-transport-python/blob/main/elastic_transport/_node/_base.py#L92) class.

Fixes #114 