### PR TITLE
Fix Read the Docs build

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,12 +1,16 @@
 version: 2
-sphinx:
-  configuration: docs/sphinx/conf.py
+
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3"
 
 python:
-  version: "3.8"
   install:
     - method: pip
       path: .
       extra_requirements:
         - develop
-    - requirements: docs/sphinx/requirements.txt
+
+sphinx:
+  fail_on_warning: true

--- a/docs/sphinx/requirements.txt
+++ b/docs/sphinx/requirements.txt
@@ -1,3 +1,0 @@
-sphinx
-furo
-sphinx-autodoc-typehints

--- a/setup.py
+++ b/setup.py
@@ -64,6 +64,10 @@ setup(
             "mock",
             "requests",
             "aiohttp",
+            # Override Read the Docs default (sphinx<2)
+            "sphinx>2",
+            "furo",
+            "sphinx-autodoc-typehints",
         ],
     },
     classifiers=[


### PR DESCRIPTION
As done in https://github.com/elastic/elasticsearch-dsl-py/pull/1668

Result: https://elastic-transport-python--117.org.readthedocs.build/en/117/