### PR TITLE
Support urllib3 1.26.x and 2.x

### DIFF
--- a/elastic_transport/_node/_http_urllib3.py
+++ b/elastic_transport/_node/_http_urllib3.py
@@ -21,6 +21,11 @@ import time
 import warnings
 from typing import Any, Dict, Optional, Union
 
+try:
+    from importlib import metadata
+except ImportError:
+    import importlib_metadata as metadata  # type: ignore[import,no-redef]
+
 import urllib3
 from urllib3.exceptions import ConnectTimeoutError, NewConnectionError, ReadTimeoutError
 from urllib3.util.retry import Retry
@@ -47,7 +52,7 @@ except (ImportError, AttributeError):
 class Urllib3HttpNode(BaseNode):
     """Default synchronous node class using the ``urllib3`` library via HTTP"""
 
-    _CLIENT_META_HTTP_CLIENT = ("ur", client_meta_version(urllib3.__version__))
+    _CLIENT_META_HTTP_CLIENT = ("ur", client_meta_version(metadata.version("urllib3")))
 
     def __init__(self, config: NodeConfig):
         super().__init__(config)
@@ -159,13 +164,13 @@ class Urllib3HttpNode(BaseNode):
             else:
                 body_to_send = None
 
-            response = self.pool.urlopen(  # type: ignore[no-untyped-call]
+            response = self.pool.urlopen(
                 method,
                 target,
                 body=body_to_send,
                 retries=Retry(False),
                 headers=request_headers,
-                **kw,
+                **kw,  # type: ignore[arg-type]
             )
             response_headers = HttpHeaders(response.headers)
             data = response.data

--- a/noxfile.py
+++ b/noxfile.py
@@ -43,10 +43,13 @@ def lint(session):
         "flake8",
         "black~=23.0",
         "isort",
-        "mypy==1.0.1",
-        "types-urllib3",
+        "mypy==1.5.1",
         "types-requests",
         "types-certifi",
+    )
+    # https://github.com/python/typeshed/issues/10786
+    session.run(
+        "python", "-m", "pip", "uninstall", "--yes", "types-urllib3", silent=True
     )
     session.install(".[develop]")
     session.run("black", "--check", "--target-version=py36", *SOURCE_FILES)

--- a/setup.py
+++ b/setup.py
@@ -51,6 +51,7 @@ setup(
         "urllib3>=1.26.2, <3",
         "certifi",
         "dataclasses; python_version<'3.7'",
+        "importlib-metadata; python_version<'3.8'",
     ],
     python_requires=">=3.6",
     extras_require={

--- a/setup.py
+++ b/setup.py
@@ -48,7 +48,7 @@ setup(
     package_data={"elastic_transport": ["py.typed"]},
     packages=packages,
     install_requires=[
-        "urllib3>=1.26.2, <2",
+        "urllib3>=1.26.2, <3",
         "certifi",
         "dataclasses; python_version<'3.7'",
     ],


### PR DESCRIPTION
This changes the assert_fingerprint hack to more directly tell urllib3 that we'll assert the fingerprint ourselves to add support for pinning root certificates, not only the leaves.

See https://github.com/elastic/elastic-transport-python/pull/105 for more context.