### PR TITLE
Fix CI to work on Python 3.12

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,15 +10,13 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v1
       - name: Set up Python 3.x
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: 3.x
       - name: Install dependencies
-        run: |
-          python3 -m pip install setuptools wheel twine
+        run: python3 -m pip install setuptools wheel twine
       - name: Build dists
-        run: |
-          python3 utils/build-dists.py
+        run: python3 utils/build-dists.py
 
   lint:
     runs-on: ubuntu-latest
@@ -26,20 +24,23 @@ jobs:
       - name: Checkout Repository
         uses: actions/checkout@v1
       - name: Set up Python 3.x
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: 3.x
       - name: Install dependencies
-        run: |
-          python3 -m pip install nox
+        run: python3 -m pip install nox
       - name: Lint the code
         run: nox -s lint
+        env:
+          # Workaround for development versions
+          # https://github.com/aio-libs/aiohttp/issues/7675
+          AIOHTTP_NO_EXTENSIONS: 1
 
   test:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12-dev"]
+        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12"]
         os: ["ubuntu-latest"]
         experimental: [false]
 

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -3,6 +3,10 @@ version: 2
 build:
   os: ubuntu-22.04
   tools:
+    # To work around https://github.com/aio-libs/aiohttp/issues/7675, we need
+    # to set AIOHTTP_NO_EXTENSIONS to 1 but it has to be done in
+    # https://readthedocs.org/dashboard/elastic-transport-python/environmentvariables/
+    # because of https://github.com/readthedocs/readthedocs.org/issues/6311
     python: "3"
 
 python:


### PR DESCRIPTION
Both GitHub Actions and ReadtheDocs have bumped "Python 3.x" from 3.11 to 3.12. The actual fix is setting `AIOHTTP_NO_EXTENSIONS`, but I applied a few other cosmetic changes too.