### PR TITLE
Always set default HTTPS port to 443

### DIFF
--- a/elastic_transport/client_utils.py
+++ b/elastic_transport/client_utils.py
@@ -186,27 +186,23 @@ def url_to_node_config(
 ) -> NodeConfig:
     """Constructs a :class:`elastic_transport.NodeConfig` instance from a URL.
     If a username/password are specified in the URL they are converted to an
-    'Authorization' header.
+    'Authorization' header. Always fills in a default port for HTTPS.
 
     :param url: URL to transform into a NodeConfig.
-    :param use_default_ports_for_scheme: If 'True' will resolve default ports for the given scheme.
+    :param use_default_ports_for_scheme: If 'True' will resolve default ports for HTTP.
     """
     try:
         parsed_url = parse_url(url)
     except LocationParseError:
         raise ValueError(f"Could not parse URL {url!r}") from None
 
-    # Only fill in a default port for HTTP and HTTPS
-    # when we know the scheme is one of those two.
     parsed_port: Optional[int] = parsed_url.port
-    if (
-        parsed_url.port is None
-        and parsed_url.scheme is not None
-        and use_default_ports_for_scheme is True
-    ):
+    if parsed_url.port is None and parsed_url.scheme is not None:
+        # Always fill in a default port for HTTPS
         if parsed_url.scheme == "https":
             parsed_port = 443
-        elif parsed_url.scheme == "http":
+        # Only fill HTTP default port when asked to explicitly
+        elif parsed_url.scheme == "http" and use_default_ports_for_scheme:
             parsed_port = 80
 
     if any(

--- a/tests/test_client_utils.py
+++ b/tests/test_client_utils.py
@@ -145,6 +145,7 @@ def test_invalid_cloud_id(cloud_id):
 @pytest.mark.parametrize(
     ["url", "node_base_url", "path_prefix"],
     [
+        ("https://localhost", "https://localhost:443", ""),
         ("http://localhost:3002", "http://localhost:3002", ""),
         ("http://127.0.0.1:3002", "http://127.0.0.1:3002", ""),
         ("http://127.0.0.1:3002/", "http://127.0.0.1:3002", ""),
@@ -156,6 +157,11 @@ def test_invalid_cloud_id(cloud_id):
         (
             "http://localhost:3002/url-prefix/",
             "http://localhost:3002/url-prefix",
+            "/url-prefix",
+        ),
+        (
+            "https://localhost/url-prefix",
+            "https://localhost:443/url-prefix",
             "/url-prefix",
         ),
         ("http://[::1]:3002/url-prefix", "http://[::1]:3002/url-prefix", "/url-prefix"),


### PR DESCRIPTION
This is the correct port most of the time, including in our cloud offering.