### PR TITLE
Mark async tests explicitly

### DIFF
--- a/tests/async_/test_async_transport.py
+++ b/tests/async_/test_async_transport.py
@@ -43,9 +43,8 @@ from elastic_transport._node._base import DEFAULT_USER_AGENT
 from elastic_transport.client_utils import DEFAULT
 from tests.conftest import AsyncDummyNode
 
-pytestmark = pytest.mark.asyncio
 
-
+@pytest.mark.asyncio
 async def test_async_transport_httpbin(httpbin_node_config):
     t = AsyncTransport([httpbin_node_config], meta_header=False)
     resp, data = await t.perform_request("GET", "/anything?key=value")
@@ -62,6 +61,7 @@ async def test_async_transport_httpbin(httpbin_node_config):
 @pytest.mark.skipif(
     sys.version_info < (3, 8), reason="Mock didn't support async before Python 3.8"
 )
+@pytest.mark.asyncio
 async def test_transport_close_node_pool():
     t = AsyncTransport([NodeConfig("http", "localhost", 443)])
     with mock.patch.object(t.node_pool.all()[0], "close") as node_close:
@@ -69,6 +69,7 @@ async def test_transport_close_node_pool():
     node_close.assert_called_with()
 
 
+@pytest.mark.asyncio
 async def test_request_with_custom_user_agent_header():
     t = AsyncTransport(
         [NodeConfig("http", "localhost", 80)],
@@ -85,6 +86,7 @@ async def test_request_with_custom_user_agent_header():
     } == t.node_pool.get().calls[0][1]
 
 
+@pytest.mark.asyncio
 async def test_body_gets_encoded_into_bytes():
     t = AsyncTransport([NodeConfig("http", "localhost", 80)], node_class=AsyncDummyNode)
 
@@ -98,6 +100,7 @@ async def test_body_gets_encoded_into_bytes():
     assert kwargs["body"] == b'{"key":"\xe4\xbd\xa0\xe5\xa5\xbd"}'
 
 
+@pytest.mark.asyncio
 async def test_body_bytes_get_passed_untouched():
     t = AsyncTransport([NodeConfig("http", "localhost", 80)], node_class=AsyncDummyNode)
 
@@ -123,6 +126,7 @@ def test_kwargs_passed_on_to_node_pool():
     assert dt is t.node_pool.max_dead_node_backoff
 
 
+@pytest.mark.asyncio
 async def test_request_will_fail_after_x_retries():
     t = AsyncTransport(
         [
@@ -145,6 +149,7 @@ async def test_request_will_fail_after_x_retries():
 
 
 @pytest.mark.parametrize("retry_on_timeout", [True, False])
+@pytest.mark.asyncio
 async def test_retry_on_timeout(retry_on_timeout):
     t = AsyncTransport(
         [
@@ -179,6 +184,7 @@ async def test_retry_on_timeout(retry_on_timeout):
         assert len(e.value.errors) == 0
 
 
+@pytest.mark.asyncio
 async def test_retry_on_status():
     t = AsyncTransport(
         [
@@ -222,6 +228,7 @@ async def test_retry_on_status():
     ]
 
 
+@pytest.mark.asyncio
 async def test_failed_connection_will_be_marked_as_dead():
     t = AsyncTransport(
         [
@@ -250,6 +257,7 @@ async def test_failed_connection_will_be_marked_as_dead():
     assert all(isinstance(error, ConnectionError) for error in e.value.errors)
 
 
+@pytest.mark.asyncio
 async def test_resurrected_connection_will_be_marked_as_live_on_success():
     for method in ("GET", "HEAD"):
         t = AsyncTransport(
@@ -270,6 +278,7 @@ async def test_resurrected_connection_will_be_marked_as_live_on_success():
         assert 1 == len(t.node_pool._dead_nodes.queue)
 
 
+@pytest.mark.asyncio
 async def test_mark_dead_error_doesnt_raise():
     t = AsyncTransport(
         [
@@ -289,6 +298,7 @@ async def test_mark_dead_error_doesnt_raise():
     mark_dead.assert_called_with(bad_node)
 
 
+@pytest.mark.asyncio
 async def test_node_class_as_string():
     t = AsyncTransport([NodeConfig("http", "localhost", 80)], node_class="aiohttp")
     assert isinstance(t.node_pool.get(), AiohttpHttpNode)
@@ -302,6 +312,7 @@ async def test_node_class_as_string():
 
 
 @pytest.mark.parametrize(["status", "boolean"], [(200, True), (299, True)])
+@pytest.mark.asyncio
 async def test_head_response_true(status, boolean):
     t = AsyncTransport(
         [NodeConfig("http", "localhost", 80, _extras={"status": status, "body": b""})],
@@ -312,6 +323,7 @@ async def test_head_response_true(status, boolean):
     assert data is None
 
 
+@pytest.mark.asyncio
 async def test_head_response_false():
     t = AsyncTransport(
         [NodeConfig("http", "localhost", 80, _extras={"status": 404, "body": b""})],
@@ -328,6 +340,7 @@ async def test_head_response_false():
     "node_class",
     ["aiohttp", AiohttpHttpNode],
 )
+@pytest.mark.asyncio
 async def test_transport_client_meta_node_class(node_class):
     t = AsyncTransport([NodeConfig("http", "localhost", 80)], node_class=node_class)
     assert (
@@ -359,6 +372,7 @@ def test_transport_and_node_are_async(node_class):
     )
 
 
+@pytest.mark.asyncio
 async def test_sniff_on_start():
     calls = []
 
@@ -385,6 +399,7 @@ async def test_sniff_on_start():
     assert sniff_options == SniffOptions(is_initial_sniff=True, sniff_timeout=0.5)
 
 
+@pytest.mark.asyncio
 async def test_sniff_before_requests():
     calls = []
 
@@ -410,6 +425,7 @@ async def test_sniff_before_requests():
     assert sniff_options == SniffOptions(is_initial_sniff=False, sniff_timeout=0.5)
 
 
+@pytest.mark.asyncio
 async def test_sniff_on_node_failure():
     calls = []
 
@@ -454,6 +470,7 @@ async def test_sniff_on_node_failure():
         {"sniff_before_requests": True},
     ],
 )
+@pytest.mark.asyncio
 async def test_error_with_sniffing_enabled_without_callback(kwargs):
     with pytest.raises(ValueError) as e:
         AsyncTransport([NodeConfig("http", "localhost", 80)], **kwargs)
@@ -461,6 +478,7 @@ async def test_error_with_sniffing_enabled_without_callback(kwargs):
     assert str(e.value) == "Enabling sniffing requires specifying a 'sniff_callback'"
 
 
+@pytest.mark.asyncio
 async def test_error_sniffing_callback_without_sniffing_enabled():
     with pytest.raises(ValueError) as e:
         AsyncTransport(
@@ -473,6 +491,7 @@ async def test_error_sniffing_callback_without_sniffing_enabled():
     )
 
 
+@pytest.mark.asyncio
 async def test_heterogeneous_node_config_warning_with_sniffing():
     with warnings.catch_warnings(record=True) as w:
         AsyncTransport(
@@ -494,6 +513,7 @@ async def test_heterogeneous_node_config_warning_with_sniffing():
 
 
 @pytest.mark.parametrize("async_sniff_callback", [True, False])
+@pytest.mark.asyncio
 async def test_sniffed_nodes_added_to_pool(async_sniff_callback):
     sniffed_nodes = [
         NodeConfig("http", "localhost", 80),
@@ -545,6 +565,7 @@ async def test_sniffed_nodes_added_to_pool(async_sniff_callback):
     assert set(sniffed_nodes) == {node.config for node in t.node_pool.all()}
 
 
+@pytest.mark.asyncio
 async def test_sniff_error_resets_lock_and_last_sniffed_at():
     def sniff_error(*_):
         raise TransportError("This is an error!")
@@ -574,6 +595,7 @@ async def _empty_sniff(*_):
 
 
 @pytest.mark.parametrize("sniff_callback", [lambda *_: [], _empty_sniff])
+@pytest.mark.asyncio
 async def test_sniff_on_start_no_results_errors(sniff_callback):
     t = AsyncTransport(
         [
@@ -592,6 +614,7 @@ async def test_sniff_on_start_no_results_errors(sniff_callback):
 
 
 @pytest.mark.parametrize("pool_size", [1, 8])
+@pytest.mark.asyncio
 async def test_multiple_tasks_test(pool_size):
     node_configs = [
         NodeConfig("http", "localhost", 80),
@@ -629,6 +652,7 @@ async def test_multiple_tasks_test(pool_size):
     assert sum([await task for task in tasks]) >= 1000
 
 
+@pytest.mark.asyncio
 async def test_httpbin(httpbin_node_config):
     t = AsyncTransport([httpbin_node_config])
     resp = await t.perform_request("GET", "/anything")

--- a/tests/async_/test_httpbin.py
+++ b/tests/async_/test_httpbin.py
@@ -25,9 +25,8 @@ from elastic_transport._node._base import DEFAULT_USER_AGENT
 
 from ..test_httpbin import parse_httpbin
 
-pytestmark = pytest.mark.asyncio
 
-
+@pytest.mark.asyncio
 async def test_simple_request(httpbin_node_config):
     t = AsyncTransport([httpbin_node_config])
 
@@ -59,6 +58,7 @@ async def test_simple_request(httpbin_node_config):
     assert all(v == data["headers"][k] for k, v in request_headers.items())
 
 
+@pytest.mark.asyncio
 async def test_node(httpbin_node_config):
     def new_node(**kwargs):
         return AiohttpHttpNode(dataclasses.replace(httpbin_node_config, **kwargs))

--- a/tests/async_/test_httpserver.py
+++ b/tests/async_/test_httpserver.py
@@ -21,9 +21,8 @@ import pytest
 
 from elastic_transport import AsyncTransport
 
-pytestmark = pytest.mark.asyncio
 
-
+@pytest.mark.asyncio
 async def test_simple_request(https_server_ip_node_config):
     with warnings.catch_warnings():
         warnings.simplefilter("error")

--- a/tests/node/test_http_aiohttp.py
+++ b/tests/node/test_http_aiohttp.py
@@ -26,10 +26,9 @@ from multidict import CIMultiDict
 from elastic_transport import AiohttpHttpNode, NodeConfig
 from elastic_transport._node._base import DEFAULT_USER_AGENT
 
-pytestmark = pytest.mark.asyncio
-
 
 class TestAiohttpHttpNode:
+    @pytest.mark.asyncio
     async def _get_mock_node(self, node_config, response_body=b"{}"):
         node = AiohttpHttpNode(node_config)
         node._create_aiohttp_session()
@@ -57,6 +56,7 @@ class TestAiohttpHttpNode:
         node.session.request = _dummy_request
         return node
 
+    @pytest.mark.asyncio
     async def test_aiohttp_options(self):
         node = await self._get_mock_node(
             NodeConfig(scheme="http", host="localhost", port=80)
@@ -85,6 +85,7 @@ class TestAiohttpHttpNode:
             ),
         }
 
+    @pytest.mark.asyncio
     async def test_aiohttp_options_fingerprint(self):
         node = await self._get_mock_node(
             NodeConfig(
@@ -121,6 +122,7 @@ class TestAiohttpHttpNode:
         "options",
         [(5, 5, 5), (None, 5, 5), (5, None, 0), (None, None, 0), (5, 5), (None, 0)],
     )
+    @pytest.mark.asyncio
     async def test_aiohttp_options_timeout(self, options):
         if len(options) == 3:
             constructor_timeout, request_timeout, aiohttp_timeout = options
@@ -157,6 +159,7 @@ class TestAiohttpHttpNode:
             ),
         }
 
+    @pytest.mark.asyncio
     async def test_http_compression(self):
         node = await self._get_mock_node(
             NodeConfig(scheme="http", host="localhost", port=80, http_compress=True)
@@ -178,6 +181,7 @@ class TestAiohttpHttpNode:
         assert gzip.decompress(kwargs["data"]) == b"{}"
 
     @pytest.mark.parametrize("http_compress", [None, False])
+    @pytest.mark.asyncio
     async def test_no_http_compression(self, http_compress):
         node = await self._get_mock_node(
             NodeConfig(
@@ -197,6 +201,7 @@ class TestAiohttpHttpNode:
         assert kwargs["data"] == b"{}"
 
     @pytest.mark.parametrize("path_prefix", ["url", "/url"])
+    @pytest.mark.asyncio
     async def test_uses_https_if_verify_certs_is_off(self, path_prefix):
         with warnings.catch_warnings(record=True) as w:
             await self._get_mock_node(
@@ -215,6 +220,7 @@ class TestAiohttpHttpNode:
             == str(w[0].message)
         )
 
+    @pytest.mark.asyncio
     async def test_uses_https_if_verify_certs_is_off_no_show_warning(self):
         with warnings.catch_warnings(record=True) as w:
             node = await self._get_mock_node(
@@ -230,6 +236,7 @@ class TestAiohttpHttpNode:
 
         assert w == []
 
+    @pytest.mark.asyncio
     async def test_merge_headers(self):
         node = await self._get_mock_node(
             NodeConfig(
@@ -254,6 +261,7 @@ class TestAiohttpHttpNode:
         }
 
     @pytest.mark.parametrize("aiohttp_fixed_head_bug", [True, False])
+    @pytest.mark.asyncio
     async def test_head_workaround(self, aiohttp_fixed_head_bug):
         from elastic_transport._node import _http_aiohttp
 
@@ -281,6 +289,7 @@ class TestAiohttpHttpNode:
             _http_aiohttp._AIOHTTP_FIXED_HEAD_BUG = prev
 
 
+@pytest.mark.asyncio
 async def test_ssl_assert_fingerprint(httpbin_cert_fingerprint):
     with warnings.catch_warnings(record=True) as w:
         node = AiohttpHttpNode(
@@ -297,6 +306,7 @@ async def test_ssl_assert_fingerprint(httpbin_cert_fingerprint):
     assert [str(x.message) for x in w if x.category != DeprecationWarning] == []
 
 
+@pytest.mark.asyncio
 async def test_default_headers():
     node = AiohttpHttpNode(NodeConfig(scheme="https", host="httpbin.org", port=443))
     resp, data = await node.perform_request("GET", "/anything")
@@ -307,6 +317,7 @@ async def test_default_headers():
     assert headers == {"Host": "httpbin.org", "User-Agent": DEFAULT_USER_AGENT}
 
 
+@pytest.mark.asyncio
 async def test_custom_headers():
     node = AiohttpHttpNode(
         NodeConfig(
@@ -336,6 +347,7 @@ async def test_custom_headers():
     }
 
 
+@pytest.mark.asyncio
 async def test_custom_user_agent():
     node = AiohttpHttpNode(
         NodeConfig(
@@ -370,6 +382,7 @@ def test_repr():
     assert "<AiohttpHttpNode(https://localhost:443)>" == repr(node)
 
 
+@pytest.mark.asyncio
 async def test_head():
     node = AiohttpHttpNode(
         NodeConfig(scheme="https", host="httpbin.org", port=443, http_compress=True)

--- a/tests/node/test_tls_versions.py
+++ b/tests/node/test_tls_versions.py
@@ -35,7 +35,6 @@ TLSv1_0_URL = "https://tls-v1-0.badssl.com:1010"
 TLSv1_1_URL = "https://tls-v1-1.badssl.com:1011"
 TLSv1_2_URL = "https://tls-v1-2.badssl.com:1012"
 
-pytestmark = pytest.mark.asyncio
 node_classes = pytest.mark.parametrize(
     "node_class", [AiohttpHttpNode, Urllib3HttpNode, RequestsHttpNode]
 )
@@ -97,6 +96,7 @@ def tlsv1_1_supported() -> bool:
     ["url", "ssl_version"],
     supported_version_params,
 )
+@pytest.mark.asyncio
 async def test_supported_tls_versions(node_class, url: str, ssl_version: int):
     if url in (TLSv1_0_URL, TLSv1_1_URL) and not tlsv1_1_supported():
         pytest.skip("TLSv1.1 isn't supported by this OpenSSL distribution")
@@ -112,6 +112,7 @@ async def test_supported_tls_versions(node_class, url: str, ssl_version: int):
     ["url", "ssl_version"],
     unsupported_version_params,
 )
+@pytest.mark.asyncio
 async def test_unsupported_tls_versions(node_class, url: str, ssl_version: int):
     node_config = url_to_node_config(url).replace(ssl_version=ssl_version)
     node = node_class(node_config)

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -31,15 +31,13 @@ from elastic_transport import (
 from elastic_transport._compat import await_if_coro
 from elastic_transport._node._base import DEFAULT_USER_AGENT
 
-pytestmark = pytest.mark.asyncio
-
-
 node_class = pytest.mark.parametrize(
     "node_class", [Urllib3HttpNode, RequestsHttpNode, AiohttpHttpNode]
 )
 
 
 @node_class
+@pytest.mark.asyncio
 async def test_debug_logging(node_class, httpbin_node_config):
     debug_logging()
 
@@ -95,6 +93,7 @@ async def test_debug_logging(node_class, httpbin_node_config):
 
 
 @node_class
+@pytest.mark.asyncio
 async def test_debug_logging_uncompressed_body(httpbin_node_config, node_class):
     debug_logging()
     stream = io.StringIO()
@@ -118,6 +117,7 @@ async def test_debug_logging_uncompressed_body(httpbin_node_config, node_class):
 
 
 @node_class
+@pytest.mark.asyncio
 async def test_debug_logging_no_body(httpbin_node_config, node_class):
     debug_logging()
     stream = io.StringIO()
@@ -138,6 +138,7 @@ async def test_debug_logging_no_body(httpbin_node_config, node_class):
 
 
 @node_class
+@pytest.mark.asyncio
 async def test_debug_logging_error(httpbin_node_config, node_class):
     debug_logging()
     stream = io.StringIO()


### PR DESCRIPTION
Previously, all files with async tests had a `pytestmark` that applied to all tests. However, it had two downsides:

 * it produced a PytestWarning on the few functions that were not async
 * it prevented adding trio tests in the same file