### PR TITLE
Fix basic auth built from percent-encoded URLs

### DIFF
--- a/elastic_transport/client_utils.py
+++ b/elastic_transport/client_utils.py
@@ -222,8 +222,10 @@ def url_to_node_config(
         # `urllib3.util.url_parse` ensures `parsed_url` is correctly
         # percent-encoded but does not percent-decode userinfo, so we have to
         # do it ourselves to build the basic auth header correctly.
-        auth = urllib.parse.unquote(parsed_url.auth)
-        username, _, password = auth.partition(":")
+        encoded_username, _, encoded_password = parsed_url.auth.partition(":")
+        username = urllib.parse.unquote(encoded_username)
+        password = urllib.parse.unquote(encoded_password)
+
         headers["authorization"] = basic_auth_to_header((username, password))
 
     host = parsed_url.host.strip("[]")

--- a/elastic_transport/client_utils.py
+++ b/elastic_transport/client_utils.py
@@ -19,6 +19,7 @@ import base64
 import binascii
 import dataclasses
 import re
+import urllib.parse
 from platform import python_version
 from typing import Optional, Tuple, TypeVar, Union
 from urllib.parse import quote as _quote
@@ -218,7 +219,11 @@ def url_to_node_config(
 
     headers = {}
     if parsed_url.auth:
-        username, _, password = parsed_url.auth.partition(":")
+        # `urllib3.util.url_parse` ensures `parsed_url` is correctly
+        # percent-encoded but does not percent-decode userinfo, so we have to
+        # do it ourselves to build the basic auth header correctly.
+        auth = urllib.parse.unquote(parsed_url.auth)
+        username, _, password = auth.partition(":")
         headers["authorization"] = basic_auth_to_header((username, password))
 
     host = parsed_url.host.strip("[]")

--- a/tests/test_client_utils.py
+++ b/tests/test_client_utils.py
@@ -236,8 +236,15 @@ def test_url_with_auth_into_authorization():
 
     node_config = url_to_node_config("http://me@example.com:password@localhost:9200")
     assert node_config.headers == {
-        "Authorization": "Basic bWUlNDBleGFtcGxlLmNvbTpwYXNzd29yZA=="
+        "Authorization": "Basic bWVAZXhhbXBsZS5jb206cGFzc3dvcmQ="
     }
+
+    # ensure username and password are passed to basic auth unmodified
+    basic_auth = basic_auth_to_header(("user@", "@password"))
+    node_config = url_to_node_config("http://user@:@password@localhost:9200")
+    assert node_config.headers == {"Authorization": basic_auth}
+    node_config = url_to_node_config("http://user%40:%40password@localhost:9200")
+    assert node_config.headers == {"Authorization": basic_auth}
 
 
 @pytest.mark.parametrize(

--- a/tests/test_client_utils.py
+++ b/tests/test_client_utils.py
@@ -240,10 +240,10 @@ def test_url_with_auth_into_authorization():
     }
 
     # ensure username and password are passed to basic auth unmodified
-    basic_auth = basic_auth_to_header(("user@", "@password"))
-    node_config = url_to_node_config("http://user@:@password@localhost:9200")
+    basic_auth = basic_auth_to_header(("user:@", "@password"))
+    node_config = url_to_node_config("http://user:@:@password@localhost:9200")
     assert node_config.headers == {"Authorization": basic_auth}
-    node_config = url_to_node_config("http://user%40:%40password@localhost:9200")
+    node_config = url_to_node_config("http://user%3A%40:%40password@localhost:9200")
     assert node_config.headers == {"Authorization": basic_auth}
 
 


### PR DESCRIPTION
Closes #141 

Tested succesfully with `Elasticsearch("https://test@:@test@@host")`.