### PR TITLE
Remove get_running_loop compat

### DIFF
--- a/elastic_transport/_async_transport.py
+++ b/elastic_transport/_async_transport.py
@@ -30,7 +30,7 @@ from typing import (
     Union,
 )
 
-from ._compat import await_if_coro, get_running_loop
+from ._compat import await_if_coro
 from ._exceptions import (
     ConnectionError,
     ConnectionTimeout,
@@ -459,6 +459,6 @@ class AsyncTransport(Transport):
         """
         if self._loop is not None:
             return  # Call at most once!
-        self._loop = get_running_loop()
+        self._loop = asyncio.get_running_loop()
         if self._sniff_on_start:
             await self.sniff(True)

--- a/elastic_transport/_compat.py
+++ b/elastic_transport/_compat.py
@@ -30,16 +30,6 @@ if sys.version_info >= (3, 7):  # dict is insert ordered on Python 3.7+
 else:
     from collections import OrderedDict as ordered_dict
 
-try:
-    from asyncio import get_running_loop
-except ImportError:
-
-    def get_running_loop() -> asyncio.AbstractEventLoop:
-        loop = asyncio.get_event_loop()
-        if not loop.is_running():
-            raise RuntimeError("no running event loop")
-        return loop
-
 
 T = TypeVar("T")
 
@@ -118,7 +108,6 @@ def warn_stacklevel() -> int:
 
 __all__ = [
     "await_if_coro",
-    "get_running_loop",
     "ordered_dict",
     "quote",
     "urlparse",

--- a/elastic_transport/_compat.py
+++ b/elastic_transport/_compat.py
@@ -15,7 +15,6 @@
 #  specific language governing permissions and limitations
 #  under the License.
 
-import asyncio
 import inspect
 import sys
 from pathlib import Path

--- a/elastic_transport/_node/_http_aiohttp.py
+++ b/elastic_transport/_node/_http_aiohttp.py
@@ -25,7 +25,7 @@ import ssl
 import warnings
 from typing import Optional, Union
 
-from .._compat import get_running_loop, warn_stacklevel
+from .._compat import warn_stacklevel
 from .._exceptions import ConnectionError, ConnectionTimeout, SecurityWarning, TlsError
 from .._models import ApiResponseMeta, HttpHeaders, NodeConfig
 from ..client_utils import DEFAULT, DefaultType, client_meta_version

--- a/elastic_transport/_node/_http_aiohttp.py
+++ b/elastic_transport/_node/_http_aiohttp.py
@@ -248,7 +248,7 @@ class AiohttpHttpNode(BaseAsyncNode):
         a chance to set AiohttpHttpNode.loop
         """
         if self._loop is None:
-            self._loop = get_running_loop()
+            self._loop = asyncio.get_running_loop()
         self.session = aiohttp.ClientSession(
             headers=self.headers,
             skip_auto_headers=("accept", "accept-encoding", "user-agent"),

--- a/tests/async_/test_async_transport.py
+++ b/tests/async_/test_async_transport.py
@@ -39,7 +39,6 @@ from elastic_transport import (
     TransportWarning,
     Urllib3HttpNode,
 )
-from elastic_transport._compat import get_running_loop
 from elastic_transport._node._base import DEFAULT_USER_AGENT
 from elastic_transport.client_utils import DEFAULT
 from tests.conftest import AsyncDummyNode
@@ -532,7 +531,7 @@ async def test_sniffed_nodes_added_to_pool(async_sniff_callback):
         NodeConfig("http", "localhost", 81),
     ]
 
-    loop = get_running_loop()
+    loop = asyncio.get_running_loop()
     sniffed_at = 0.0
 
     # Test that we accept both sync and async sniff_callbacks
@@ -650,7 +649,7 @@ async def test_multiple_tasks_test(pool_size):
         sniff_callback=sniff_callback,
     )
 
-    loop = get_running_loop()
+    loop = asyncio.get_running_loop()
     start = loop.time()
 
     async def run_requests():


### PR DESCRIPTION
It's always available in Python 3.7 and above.