### PR TITLE
Add minimal OpenTelemetry instrumentation

### DIFF
--- a/elastic_transport/_node/_http_urllib3.py
+++ b/elastic_transport/_node/_http_urllib3.py
@@ -24,7 +24,7 @@ from typing import Any, Dict, Optional, Union
 try:
     from importlib import metadata
 except ImportError:
-    import importlib_metadata as metadata  # type: ignore[import-not-found,no-redef]
+    import importlib_metadata as metadata  # type: ignore[no-redef]
 
 import urllib3
 from urllib3.exceptions import ConnectTimeoutError, NewConnectionError, ReadTimeoutError

--- a/elastic_transport/_otel.py
+++ b/elastic_transport/_otel.py
@@ -15,6 +15,8 @@
 #  specific language governing permissions and limitations
 #  under the License.
 
+from __future__ import annotations
+
 import contextlib
 import os
 import typing

--- a/elastic_transport/_otel.py
+++ b/elastic_transport/_otel.py
@@ -1,0 +1,51 @@
+#  Licensed to Elasticsearch B.V. under one or more contributor
+#  license agreements. See the NOTICE file distributed with
+#  this work for additional information regarding copyright
+#  ownership. Elasticsearch B.V. licenses this file to you under
+#  the Apache License, Version 2.0 (the "License"); you may
+#  not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+# 	http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing,
+#  software distributed under the License is distributed on an
+#  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+#  KIND, either express or implied.  See the License for the
+#  specific language governing permissions and limitations
+#  under the License.
+
+import contextlib
+import os
+import typing
+
+try:
+    from opentelemetry import trace
+
+    _tracer: trace.Tracer | None = trace.get_tracer("elastic-transport")
+except ModuleNotFoundError:
+    _tracer = None
+
+
+ENABLED_ENV_VAR = "OTEL_PYTHON_INSTRUMENTATION_ELASTICSEARCH_ENABLED"
+
+
+class OpenTelemetry:
+    def __init__(self, enabled: bool | None = None, tracer: trace.Tracer | None = None):
+        if enabled is None:
+            enabled = os.environ.get(ENABLED_ENV_VAR, "false") != "false"
+        self.tracer = tracer or _tracer
+        self.enabled = enabled and self.tracer is not None
+        print(self.enabled)
+
+    @contextlib.contextmanager
+    def span(self, method: str) -> typing.Generator[None, None, None]:
+        if not self.enabled or self.tracer is None:
+            yield
+            return
+
+        span_name = method
+        with self.tracer.start_as_current_span(span_name) as span:
+            span.set_attribute("http.request.method", method)
+            span.set_attribute("db.system", "elasticsearch")
+            yield

--- a/elastic_transport/_otel.py
+++ b/elastic_transport/_otel.py
@@ -38,7 +38,6 @@ class OpenTelemetry:
             enabled = os.environ.get(ENABLED_ENV_VAR, "false") != "false"
         self.tracer = tracer or _tracer
         self.enabled = enabled and self.tracer is not None
-        print(self.enabled)
 
     @contextlib.contextmanager
     def span(self, method: str) -> typing.Generator[None, None, None]:

--- a/setup.py
+++ b/setup.py
@@ -52,7 +52,6 @@ setup(
     install_requires=[
         "urllib3>=1.26.2, <3",
         "certifi",
-        "dataclasses; python_version<'3.7'",
         "importlib-metadata; python_version<'3.8'",
     ],
     python_requires=">=3.7",
@@ -69,6 +68,8 @@ setup(
             "aiohttp",
             "httpx",
             "respx",
+            "opentelemetry-api",
+            "opentelemetry-sdk",
             # Override Read the Docs default (sphinx<2)
             "sphinx>2",
             "furo",

--- a/tests/test_otel.py
+++ b/tests/test_otel.py
@@ -1,0 +1,41 @@
+#  Licensed to Elasticsearch B.V. under one or more contributor
+#  license agreements. See the NOTICE file distributed with
+#  this work for additional information regarding copyright
+#  ownership. Elasticsearch B.V. licenses this file to you under
+#  the Apache License, Version 2.0 (the "License"); you may
+#  not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+# 	http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing,
+#  software distributed under the License is distributed on an
+#  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+#  KIND, either express or implied.  See the License for the
+#  specific language governing permissions and limitations
+#  under the License.
+
+
+from opentelemetry.sdk.trace import TracerProvider, export
+from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
+
+from elastic_transport._otel import OpenTelemetry
+
+
+def test_span():
+    tracer_provider = TracerProvider()
+    memory_exporter = InMemorySpanExporter()
+    span_processor = export.SimpleSpanProcessor(memory_exporter)
+    tracer_provider.add_span_processor(span_processor)
+    tracer = tracer_provider.get_tracer(__name__)
+
+    otel = OpenTelemetry(enabled=True, tracer=tracer)
+    with otel.span("GET", "my-endpoint"):
+        pass
+
+    spans = memory_exporter.get_finished_spans()
+    assert len(spans) == 1
+    assert spans[0].attributes == {
+        "http.request.method": "GET",
+        "db.system": "elasticsearch",
+    }

--- a/tests/test_otel.py
+++ b/tests/test_otel.py
@@ -30,7 +30,7 @@ def test_span():
     tracer = tracer_provider.get_tracer(__name__)
 
     otel = OpenTelemetry(enabled=True, tracer=tracer)
-    with otel.span("GET", "my-endpoint"):
+    with otel.span("GET"):
         pass
 
     spans = memory_exporter.get_finished_spans()


### PR DESCRIPTION
Relates https://github.com/elastic/elasticsearch-py/issues/2435

This pull request introduces minimal OpenTelemetry instrumentation, without:

 * documentation
 * configuration, except to enable it (it is disabled by default)
 * help for the client (to get the endpoint id and path parts)
 * help from the underlying HTTP clients (to get connection details)

However, it contains the basic scaffolding and can be used to send a basic trace containing the method name to Elastic APM:

![image](https://github.com/elastic/elastic-transport-python/assets/42327/d3706ff6-9a65-430f-beca-bdb1b160f0ff)

Thanks @estolfo for the help. As you know, I was heavily inspired by the Ruby implementation.