### PR TITLE
Accept endpoint_id and path_params from client

### DIFF
--- a/elastic_transport/_async_transport.py
+++ b/elastic_transport/_async_transport.py
@@ -212,7 +212,7 @@ class AsyncTransport(Transport):
         :arg client_meta: Extra client metadata key-value pairs to send in the client meta header.
         :arg endpoint_id: The endpoint id of the request, such as `ml.close_job`.
             Used for OpenTelemetry instrumentation.
-        :arg path_parths: Dictionary with all dynamic value in the url path.
+        :arg path_paths: Dictionary with all dynamic value in the url path.
             Used for OpenTelemetry instrumentation.
         :returns: Tuple of the :class:`elastic_transport.ApiResponseMeta` with the deserialized response.
         """

--- a/elastic_transport/_async_transport.py
+++ b/elastic_transport/_async_transport.py
@@ -173,7 +173,7 @@ class AsyncTransport(Transport):
         # sniffing. Uses '_sniffing_task' instead.
         self._sniffing_lock = None  # type: ignore[assignment]
 
-    async def perform_request(  # type: ignore[override,return]
+    async def perform_request(  # type: ignore[override]
         self,
         method: str,
         target: str,
@@ -185,6 +185,8 @@ class AsyncTransport(Transport):
         retry_on_timeout: Union[bool, DefaultType] = DEFAULT,
         request_timeout: Union[Optional[float], DefaultType] = DEFAULT,
         client_meta: Union[Tuple[Tuple[str, str], ...], DefaultType] = DEFAULT,
+        endpoint_id: Union[str, DefaultType] = DEFAULT,
+        path_parts: Union[Mapping[str, str], DefaultType] = DEFAULT,
     ) -> TransportApiResponse:
         """
         Perform the actual request. Retrieve a node from the node
@@ -208,8 +210,42 @@ class AsyncTransport(Transport):
         :arg retry_on_timeout: Set to true to retry after timeout errors.
         :arg request_timeout: Amount of time to wait for a response to fail with a timeout error.
         :arg client_meta: Extra client metadata key-value pairs to send in the client meta header.
+        :arg endpoint_id: The endpoint id of the request, such as `ml.close_job`.
+            Used for OpenTelemetry instrumentation.
+        :arg path_parths: Dictionary with all dynamic value in the url path.
+            Used for OpenTelemetry instrumentation.
         :returns: Tuple of the :class:`elastic_transport.ApiResponseMeta` with the deserialized response.
         """
+        with self.otel.span(
+            method,
+            endpoint_id=resolve_default(endpoint_id, None),
+            path_parts=resolve_default(path_parts, {}),
+        ):
+            return await self._perform_request(
+                method,
+                target,
+                body=body,
+                headers=headers,
+                max_retries=max_retries,
+                retry_on_status=retry_on_status,
+                retry_on_timeout=retry_on_timeout,
+                request_timeout=request_timeout,
+                client_meta=client_meta,
+            )
+
+    async def _perform_request(  # type: ignore[override,return]
+        self,
+        method: str,
+        target: str,
+        *,
+        body: Optional[Any] = None,
+        headers: Union[Mapping[str, Any], DefaultType] = DEFAULT,
+        max_retries: Union[int, DefaultType] = DEFAULT,
+        retry_on_status: Union[Collection[int], DefaultType] = DEFAULT,
+        retry_on_timeout: Union[bool, DefaultType] = DEFAULT,
+        request_timeout: Union[Optional[float], DefaultType] = DEFAULT,
+        client_meta: Union[Tuple[Tuple[str, str], ...], DefaultType] = DEFAULT,
+    ) -> TransportApiResponse:
         await self._async_call()
 
         if headers is DEFAULT:

--- a/elastic_transport/_transport.py
+++ b/elastic_transport/_transport.py
@@ -268,6 +268,8 @@ class Transport:
         retry_on_timeout: Union[bool, DefaultType] = DEFAULT,
         request_timeout: Union[Optional[float], DefaultType] = DEFAULT,
         client_meta: Union[Tuple[Tuple[str, str], ...], DefaultType] = DEFAULT,
+        endpoint_id: Union[str, DefaultType] = DEFAULT,
+        path_parts: Union[Mapping[str, str], DefaultType] = DEFAULT,
     ) -> TransportApiResponse:
         """
         Perform the actual request. Retrieve a node from the node
@@ -291,9 +293,17 @@ class Transport:
         :arg retry_on_timeout: Set to true to retry after timeout errors.
         :arg request_timeout: Amount of time to wait for a response to fail with a timeout error.
         :arg client_meta: Extra client metadata key-value pairs to send in the client meta header.
+        :arg endpoint_id: The endpoint id of the request, such as `ml.close_job`.
+            Used for OpenTelemetry instrumentation.
+        :arg path_parths: Dictionary with all dynamic value in the url path.
+            Used for OpenTelemetry instrumentation.
         :returns: Tuple of the :class:`elastic_transport.ApiResponseMeta` with the deserialized response.
         """
-        with self.otel.span(method):
+        with self.otel.span(
+            method,
+            endpoint_id=resolve_default(endpoint_id, None),
+            path_parts=resolve_default(path_parts, {}),
+        ):
             return self._perform_request(
                 method,
                 target,

--- a/elastic_transport/_transport.py
+++ b/elastic_transport/_transport.py
@@ -295,7 +295,7 @@ class Transport:
         :arg client_meta: Extra client metadata key-value pairs to send in the client meta header.
         :arg endpoint_id: The endpoint id of the request, such as `ml.close_job`.
             Used for OpenTelemetry instrumentation.
-        :arg path_parths: Dictionary with all dynamic value in the url path.
+        :arg path_paths: Dictionary with all dynamic value in the url path.
             Used for OpenTelemetry instrumentation.
         :returns: Tuple of the :class:`elastic_transport.ApiResponseMeta` with the deserialized response.
         """

--- a/tests/test_otel.py
+++ b/tests/test_otel.py
@@ -36,7 +36,7 @@ def test_minimal_span():
     tracer, memory_exporter = setup_tracing()
 
     otel = OpenTelemetry(enabled=True, tracer=tracer)
-    with otel.span("GET", path_parts={}):
+    with otel.span("GET", endpoint_id=None, path_parts={}):
         pass
 
     spans = memory_exporter.get_finished_spans()
@@ -52,7 +52,7 @@ def test_detailed_span():
     tracer, memory_exporter = setup_tracing()
     otel = OpenTelemetry(enabled=True, tracer=tracer)
     with otel.span(
-        "GET", "ml.close_job", path_parts={"job_id": "my-job", "foo": "bar"}
+        "GET", endpoint_id="ml.close_job", path_parts={"job_id": "my-job", "foo": "bar"}
     ):
         pass
 

--- a/tests/test_otel.py
+++ b/tests/test_otel.py
@@ -22,20 +22,46 @@ from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanE
 from elastic_transport._otel import OpenTelemetry
 
 
-def test_span():
+def setup_tracing():
     tracer_provider = TracerProvider()
     memory_exporter = InMemorySpanExporter()
     span_processor = export.SimpleSpanProcessor(memory_exporter)
     tracer_provider.add_span_processor(span_processor)
     tracer = tracer_provider.get_tracer(__name__)
 
+    return tracer, memory_exporter
+
+
+def test_minimal_span():
+    tracer, memory_exporter = setup_tracing()
+
     otel = OpenTelemetry(enabled=True, tracer=tracer)
-    with otel.span("GET"):
+    with otel.span("GET", path_parts={}):
         pass
 
     spans = memory_exporter.get_finished_spans()
     assert len(spans) == 1
+    assert spans[0].name == "GET"
     assert spans[0].attributes == {
         "http.request.method": "GET",
         "db.system": "elasticsearch",
+    }
+
+
+def test_detailed_span():
+    tracer, memory_exporter = setup_tracing()
+    otel = OpenTelemetry(enabled=True, tracer=tracer)
+    with otel.span(
+        "GET", "ml.close_job", path_parts={"job_id": "my-job", "foo": "bar"}
+    ):
+        pass
+
+    spans = memory_exporter.get_finished_spans()
+    assert len(spans) == 1
+    assert spans[0].name == "ml.close_job"
+    assert spans[0].attributes == {
+        "http.request.method": "GET",
+        "db.system": "elasticsearch",
+        "db.elasticsearch.path_parts.job_id": "my-job",
+        "db.elasticsearch.path_parts.foo": "bar",
     }


### PR DESCRIPTION
Relates https://github.com/elastic/elasticsearch-py/issues/2435

This pull request changes `perform_request` to optionally accept `endpoint_id` and `path_parts` from the Elasticsearch client. Coupled with https://github.com/elastic/elasticsearch-py/pull/2457, this fixes the span name:

![image](https://github.com/elastic/elasticsearch-py/assets/42327/77340840-2d7f-482e-9a1f-1d95bbd5baed)

and adds path parts attributes (Elastic APM replaces dots with underscores):

![image](https://github.com/elastic/elasticsearch-py/assets/42327/81c45f08-9999-4f75-b785-89b282c59d50)

I also added support for AsyncTransport:

![image](https://github.com/elastic/elastic-transport-python/assets/42327/95dd155e-05ed-4f87-91dc-4ef6c5ce1945)

It was convenient because the elasticsearch-py changes also apply to the async API, but I can open a separate pull request to bring OTel support to AsyncTransport first if you prefer.

I have done all my testing manually but I do plan to add an integration test in the future.