### PR TITLE
Add optional orjson serializer support

### DIFF
--- a/docs/sphinx/serializers.rst
+++ b/docs/sphinx/serializers.rst
@@ -9,6 +9,9 @@ Serializers
 .. autoclass:: JsonSerializer
    :members:
 
+.. autoclass:: OrjsonSerializer
+   :members:
+
 .. autoclass:: TextSerializer
    :members:
 

--- a/elastic_transport/__init__.py
+++ b/elastic_transport/__init__.py
@@ -97,6 +97,13 @@ __all__ = [
     "Urllib3HttpNode",
 ]
 
+try:
+    from elastic_transport._serializer import OrjsonSerializer  # noqa: F401
+
+    __all__.append("OrjsonSerializer")
+except ModuleNotFoundError:
+    pass
+
 _logger = logging.getLogger("elastic_transport")
 _logger.addHandler(logging.NullHandler())
 del _logger

--- a/setup.py
+++ b/setup.py
@@ -70,6 +70,7 @@ setup(
             "respx",
             "opentelemetry-api",
             "opentelemetry-sdk",
+            "orjson",
             # Override Read the Docs default (sphinx<2)
             "sphinx>2",
             "furo",


### PR DESCRIPTION
Based on https://gist.github.com/sethmlarson/5c37bd0cc1bbb5c40d8b90860e98de7f with tips from @karmi and @honzakral.

I'm not enabling it automatically for now due to stricter UTF-8 behavior and different handling of NaN. Will require a companion PR in elasticsearch-py.