### PR TITLE
Set OpenTelemetry db.operation attribute

### DIFF
--- a/elastic_transport/_otel.py
+++ b/elastic_transport/_otel.py
@@ -55,7 +55,8 @@ class OpenTelemetry:
         with self.tracer.start_as_current_span(span_name) as span:
             span.set_attribute("http.request.method", method)
             span.set_attribute("db.system", "elasticsearch")
-            span.set_attribute("db.operation", endpoint_id)
+            if endpoint_id is not None:
+                span.set_attribute("db.operation", endpoint_id)
             for key, value in path_parts.items():
                 span.set_attribute(f"db.elasticsearch.path_parts.{key}", value)
             yield

--- a/elastic_transport/_otel.py
+++ b/elastic_transport/_otel.py
@@ -55,6 +55,7 @@ class OpenTelemetry:
         with self.tracer.start_as_current_span(span_name) as span:
             span.set_attribute("http.request.method", method)
             span.set_attribute("db.system", "elasticsearch")
+            span.set_attribute("db.operation", endpoint_id)
             for key, value in path_parts.items():
                 span.set_attribute(f"db.elasticsearch.path_parts.{key}", value)
             yield

--- a/tests/test_otel.py
+++ b/tests/test_otel.py
@@ -62,6 +62,7 @@ def test_detailed_span():
     assert spans[0].attributes == {
         "http.request.method": "GET",
         "db.system": "elasticsearch",
+        "db.operation": "ml.close_job",
         "db.elasticsearch.path_parts.job_id": "my-job",
         "db.elasticsearch.path_parts.foo": "bar",
     }


### PR DESCRIPTION
I missed this attribute when working on https://github.com/elastic/elastic-transport-python/pull/151, as I was too focused on the span name.

~I'm not checking if it's None, because `set_attribute` appears to be doing it already (as `test_minimal_span` passes without modifications).~ Actually I am checking now because mypy complains otherwise.