### PR TITLE
Set OpenTelemetry db.operation attribute

### DIFF
--- a/elastic_transport/_async_transport.py
+++ b/elastic_transport/_async_transport.py
@@ -220,8 +220,8 @@ class AsyncTransport(Transport):
             method,
             endpoint_id=resolve_default(endpoint_id, None),
             path_parts=resolve_default(path_parts, {}),
-        ):
-            return await self._perform_request(
+        ) as span:
+            response = await self._perform_request(
                 method,
                 target,
                 body=body,
@@ -232,6 +232,8 @@ class AsyncTransport(Transport):
                 request_timeout=request_timeout,
                 client_meta=client_meta,
             )
+            span.set_elastic_cloud_metadata(response.meta.headers)
+            return response
 
     async def _perform_request(  # type: ignore[override,return]
         self,

--- a/elastic_transport/_otel.py
+++ b/elastic_transport/_otel.py
@@ -55,6 +55,8 @@ class OpenTelemetry:
         with self.tracer.start_as_current_span(span_name) as span:
             span.set_attribute("http.request.method", method)
             span.set_attribute("db.system", "elasticsearch")
+            if endpoint_id is not None:
+                span.set_attribute("db.operation", endpoint_id)
             for key, value in path_parts.items():
                 span.set_attribute(f"db.elasticsearch.path_parts.{key}", value)
             yield

--- a/elastic_transport/_transport.py
+++ b/elastic_transport/_transport.py
@@ -303,8 +303,8 @@ class Transport:
             method,
             endpoint_id=resolve_default(endpoint_id, None),
             path_parts=resolve_default(path_parts, {}),
-        ):
-            return self._perform_request(
+        ) as span:
+            api_response = self._perform_request(
                 method,
                 target,
                 body=body,
@@ -315,6 +315,8 @@ class Transport:
                 request_timeout=request_timeout,
                 client_meta=client_meta,
             )
+            span.set_elastic_cloud_metadata(api_response.meta.headers)
+            return api_response
 
     def _perform_request(  # type: ignore[return]
         self,

--- a/tests/test_otel.py
+++ b/tests/test_otel.py
@@ -53,8 +53,13 @@ def test_detailed_span():
     otel = OpenTelemetry(enabled=True, tracer=tracer)
     with otel.span(
         "GET", endpoint_id="ml.close_job", path_parts={"job_id": "my-job", "foo": "bar"}
-    ):
-        pass
+    ) as span:
+        span.set_elastic_cloud_metadata(
+            {
+                "X-Found-Handling-Cluster": "e9106fc68e3044f0b1475b04bf4ffd5f",
+                "X-Found-Handling-Instance": "instance-0000000001",
+            }
+        )
 
     spans = memory_exporter.get_finished_spans()
     assert len(spans) == 1
@@ -65,4 +70,6 @@ def test_detailed_span():
         "db.operation": "ml.close_job",
         "db.elasticsearch.path_parts.job_id": "my-job",
         "db.elasticsearch.path_parts.foo": "bar",
+        "db.elasticsearch.cluster.name": "e9106fc68e3044f0b1475b04bf4ffd5f",
+        "db.elasticsearch.node.name": "instance-0000000001",
     }

--- a/tests/test_otel.py
+++ b/tests/test_otel.py
@@ -62,6 +62,7 @@ def test_detailed_span():
     assert spans[0].attributes == {
         "http.request.method": "GET",
         "db.system": "elasticsearch",
+        "db.operation": "ml.close_job",
         "db.elasticsearch.path_parts.job_id": "my-job",
         "db.elasticsearch.path_parts.foo": "bar",
     }


### PR DESCRIPTION
Relates https://github.com/elastic/elasticsearch-py/issues/2435, and builds on https://github.com/elastic/elastic-transport-python/pull/153.

Since we only get the headers after the request is finished, the context manager now yields a `OpenTelemetrySpan` class that can be used to set attributes. I use it here to set specific Elastic Cloud attributes and will use it in each HTTP implementation to set `url.full`, `server.address` and `server.port `.