### PR TITLE
Support db.statement, server and url attributes

### DIFF
--- a/elastic_transport/_otel.py
+++ b/elastic_transport/_otel.py
@@ -19,7 +19,7 @@ from __future__ import annotations
 
 import contextlib
 import os
-from typing import Any, Generator, Mapping, Optional
+from typing import Generator, Mapping, Optional
 
 try:
     from opentelemetry import trace
@@ -90,8 +90,6 @@ class OpenTelemetrySpan:
     def set_db_statement(self, serialized_body: bytes) -> None:
         if self.otel_span is None:
             return
-
-        print(f"{self.body_strategy=} {self.endpoint_id=}")
 
         if self.body_strategy == "omit":
             return

--- a/elastic_transport/_otel.py
+++ b/elastic_transport/_otel.py
@@ -19,7 +19,7 @@ from __future__ import annotations
 
 import contextlib
 import os
-from typing import Generator, Mapping, Optional
+from typing import Any, Generator, Mapping, Optional
 
 try:
     from opentelemetry import trace
@@ -30,32 +30,96 @@ except ModuleNotFoundError:
     _tracer = None
 
 
+# Valid values for the enabled config are 'true' and 'false'. Default is 'true'.
 ENABLED_ENV_VAR = "OTEL_PYTHON_INSTRUMENTATION_ELASTICSEARCH_ENABLED"
+# Describes how to handle search queries in the request body when assigned to
+# a span attribute.
+# Valid values are 'omit' and 'raw'.
+# Default is 'omit' as 'raw' has security implications.
+BODY_STRATEGY_ENV_VAR = "OTEL_PYTHON_INSTRUMENTATION_ELASTICSEARCH_CAPTURE_SEARCH_QUERY"
+DEFAULT_BODY_STRATEGY = "omit"
+
+# A list of the Elasticsearch endpoints that qualify as "search" endpoints. The search query in
+# the request body may be captured for these endpoints, depending on the body capture strategy.
+SEARCH_ENDPOINTS = (
+    "search",
+    "async_search.submit",
+    "msearch",
+    "eql.search",
+    "esql.query",
+    "terms_enum",
+    "search_template",
+    "msearch_template",
+    "render_search_template",
+)
 
 
 class OpenTelemetrySpan:
-    def __init__(self, otel_span: Optional[Span]):
+    def __init__(
+        self,
+        otel_span: Optional[Span],
+        endpoint_id: Optional[str] = None,
+        body_strategy: Optional[str] = None,
+    ):
         self.otel_span = otel_span
+        self.body_strategy = body_strategy
+        self.endpoint_id = endpoint_id
 
-    def set_attribute(self, key: str, value: str) -> None:
-        if self.otel_span is not None:
-            self.otel_span.set_attribute(key, value)
+    def set_node_metadata(
+        self, host: str, port: int, base_url: str, target: str
+    ) -> None:
+        if self.otel_span is None:
+            return
+
+        # url.full does not contain auth info which is passed as headers
+        self.otel_span.set_attribute("url.full", base_url + target)
+        self.otel_span.set_attribute("server.address", host)
+        self.otel_span.set_attribute("server.port", port)
 
     def set_elastic_cloud_metadata(self, headers: Mapping[str, str]) -> None:
+        if self.otel_span is None:
+            return
+
         cluster_name = headers.get("X-Found-Handling-Cluster")
         if cluster_name is not None:
-            self.set_attribute("db.elasticsearch.cluster.name", cluster_name)
+            self.otel_span.set_attribute("db.elasticsearch.cluster.name", cluster_name)
         node_name = headers.get("X-Found-Handling-Instance")
         if node_name is not None:
-            self.set_attribute("db.elasticsearch.node.name", node_name)
+            self.otel_span.set_attribute("db.elasticsearch.node.name", node_name)
+
+    def set_db_statement(self, serialized_body: bytes) -> None:
+        if self.otel_span is None:
+            return
+
+        print(f"{self.body_strategy=} {self.endpoint_id=}")
+
+        if self.body_strategy == "omit":
+            return
+        elif self.body_strategy == "raw" and self.endpoint_id in SEARCH_ENDPOINTS:
+            print("set", serialized_body)
+            self.otel_span.set_attribute(
+                "db.statement", serialized_body.decode("utf-8")
+            )
 
 
 class OpenTelemetry:
-    def __init__(self, enabled: bool | None = None, tracer: trace.Tracer | None = None):
+    def __init__(
+        self,
+        enabled: bool | None = None,
+        tracer: trace.Tracer | None = None,
+        body_strategy: str | None = None,
+    ):
         if enabled is None:
             enabled = os.environ.get(ENABLED_ENV_VAR, "false") != "false"
         self.tracer = tracer or _tracer
         self.enabled = enabled and self.tracer is not None
+
+        if body_strategy is not None:
+            self.body_strategy = body_strategy
+        else:
+            self.body_strategy = os.environ.get(
+                BODY_STRATEGY_ENV_VAR, DEFAULT_BODY_STRATEGY
+            )
 
     @contextlib.contextmanager
     def span(
@@ -77,4 +141,9 @@ class OpenTelemetry:
                 otel_span.set_attribute("db.operation", endpoint_id)
             for key, value in path_parts.items():
                 otel_span.set_attribute(f"db.elasticsearch.path_parts.{key}", value)
-            yield OpenTelemetrySpan(otel_span)
+
+            yield OpenTelemetrySpan(
+                otel_span,
+                endpoint_id=endpoint_id,
+                body_strategy=self.body_strategy,
+            )

--- a/elastic_transport/_otel.py
+++ b/elastic_transport/_otel.py
@@ -94,7 +94,6 @@ class OpenTelemetrySpan:
         if self.body_strategy == "omit":
             return
         elif self.body_strategy == "raw" and self.endpoint_id in SEARCH_ENDPOINTS:
-            print("set", serialized_body)
             self.otel_span.set_attribute(
                 "db.statement", serialized_body.decode("utf-8")
             )

--- a/tests/test_otel.py
+++ b/tests/test_otel.py
@@ -59,7 +59,7 @@ def test_no_span():
 
 def test_enabled():
     otel = OpenTelemetry()
-    assert otel.enabled == bool(os.environ.get(ENABLED_ENV_VAR, "false") != "false")
+    assert otel.enabled == (os.environ.get(ENABLED_ENV_VAR, "false") != "false")
 
 
 def test_minimal_span():

--- a/tests/test_otel.py
+++ b/tests/test_otel.py
@@ -59,7 +59,7 @@ def test_no_span():
 
 def test_enabled():
     otel = OpenTelemetry()
-    assert otel.enabled == os.environ.get(ENABLED_ENV_VAR, "false") != "false"
+    assert otel.enabled == bool(os.environ.get(ENABLED_ENV_VAR, "false") != "false")
 
 
 def test_minimal_span():

--- a/tests/test_otel.py
+++ b/tests/test_otel.py
@@ -15,11 +15,13 @@
 #  specific language governing permissions and limitations
 #  under the License.
 
+import os
 
 from opentelemetry.sdk.trace import TracerProvider, export
 from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
 
-from elastic_transport._otel import OpenTelemetry
+from elastic_transport import JsonSerializer
+from elastic_transport._otel import ENABLED_ENV_VAR, OpenTelemetry
 
 
 def setup_tracing():
@@ -30,6 +32,34 @@ def setup_tracing():
     tracer = tracer_provider.get_tracer(__name__)
 
     return tracer, memory_exporter
+
+
+def test_no_span():
+    # With telemetry disabled, those calls should not raise
+    otel = OpenTelemetry(enabled=False)
+    with otel.span(
+        "GET",
+        endpoint_id="ml.open_job",
+        path_parts={"job_id": "my-job"},
+    ) as span:
+        span.set_db_statement(JsonSerializer().dumps({"timeout": "1m"}))
+        span.set_node_metadata(
+            "localhost",
+            9200,
+            "http://localhost:9200/",
+            "_ml/anomaly_detectors/my-job/_open",
+        )
+        span.set_elastic_cloud_metadata(
+            {
+                "X-Found-Handling-Cluster": "e9106fc68e3044f0b1475b04bf4ffd5f",
+                "X-Found-Handling-Instance": "instance-0000000001",
+            }
+        )
+
+
+def test_enabled():
+    otel = OpenTelemetry()
+    assert otel.enabled == bool(os.environ.get(ENABLED_ENV_VAR, "false") != "false")
 
 
 def test_minimal_span():
@@ -52,8 +82,17 @@ def test_detailed_span():
     tracer, memory_exporter = setup_tracing()
     otel = OpenTelemetry(enabled=True, tracer=tracer)
     with otel.span(
-        "GET", endpoint_id="ml.close_job", path_parts={"job_id": "my-job", "foo": "bar"}
+        "GET",
+        endpoint_id="ml.open_job",
+        path_parts={"job_id": "my-job"},
     ) as span:
+        span.set_db_statement(JsonSerializer().dumps({"timeout": "1m"}))
+        span.set_node_metadata(
+            "localhost",
+            9200,
+            "http://localhost:9200/",
+            "_ml/anomaly_detectors/my-job/_open",
+        )
         span.set_elastic_cloud_metadata(
             {
                 "X-Found-Handling-Cluster": "e9106fc68e3044f0b1475b04bf4ffd5f",
@@ -63,13 +102,32 @@ def test_detailed_span():
 
     spans = memory_exporter.get_finished_spans()
     assert len(spans) == 1
-    assert spans[0].name == "ml.close_job"
+    assert spans[0].name == "ml.open_job"
+    assert spans[0].attributes == {
+        "http.request.method": "GET",
+        "url.full": "http://localhost:9200/_ml/anomaly_detectors/my-job/_open",
+        "server.address": "localhost",
+        "server.port": 9200,
+        "db.system": "elasticsearch",
+        "db.operation": "ml.open_job",
+        "db.elasticsearch.path_parts.job_id": "my-job",
+        "db.elasticsearch.cluster.name": "e9106fc68e3044f0b1475b04bf4ffd5f",
+        "db.elasticsearch.node.name": "instance-0000000001",
+    }
+
+
+def test_db_statement():
+    tracer, memory_exporter = setup_tracing()
+    otel = OpenTelemetry(enabled=True, tracer=tracer, body_strategy="raw")
+    with otel.span("GET", endpoint_id="search", path_parts={}) as span:
+        span.set_db_statement(JsonSerializer().dumps({"query": {"match_all": {}}}))
+
+    spans = memory_exporter.get_finished_spans()
+    assert len(spans) == 1
+    assert spans[0].name == "search"
     assert spans[0].attributes == {
         "http.request.method": "GET",
         "db.system": "elasticsearch",
-        "db.operation": "ml.close_job",
-        "db.elasticsearch.path_parts.job_id": "my-job",
-        "db.elasticsearch.path_parts.foo": "bar",
-        "db.elasticsearch.cluster.name": "e9106fc68e3044f0b1475b04bf4ffd5f",
-        "db.elasticsearch.node.name": "instance-0000000001",
+        "db.operation": "search",
+        "db.statement": '{"query":{"match_all":{}}}',
     }

--- a/tests/test_otel.py
+++ b/tests/test_otel.py
@@ -59,7 +59,7 @@ def test_no_span():
 
 def test_enabled():
     otel = OpenTelemetry()
-    assert otel.enabled == bool(os.environ.get(ENABLED_ENV_VAR, "false") != "false")
+    assert otel.enabled == os.environ.get(ENABLED_ENV_VAR, "false") != "false"
 
 
 def test_minimal_span():


### PR DESCRIPTION
Relates https://github.com/elastic/elasticsearch-py/issues/2435

Since sanitization is complicated and we're still discussing the best way to do it, I have left it out. It's OK as `db.statement` is not required by the semantic conventions.