### PR TITLE
Remove last uses of mock

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -63,7 +63,6 @@ setup(
             "pytest-asyncio",
             "pytest-httpserver",
             "trustme",
-            "mock",
             "requests",
             "aiohttp",
             "httpx",

--- a/tests/node/test_http_requests.py
+++ b/tests/node/test_http_requests.py
@@ -18,10 +18,10 @@
 import gzip
 import ssl
 import warnings
+from unittest.mock import Mock, patch
 
 import pytest
 import requests
-from mock import Mock, patch
 from requests.auth import HTTPBasicAuth
 
 from elastic_transport import NodeConfig, RequestsHttpNode

--- a/tests/node/test_http_urllib3.py
+++ b/tests/node/test_http_urllib3.py
@@ -19,10 +19,10 @@ import gzip
 import re
 import ssl
 import warnings
+from unittest.mock import Mock, patch
 
 import pytest
 import urllib3
-from mock import Mock, patch
 from urllib3.response import HTTPHeaderDict
 
 from elastic_transport import NodeConfig, TransportError, Urllib3HttpNode


### PR DESCRIPTION
The node tests still relied on the external mock library for mocking, whereas other tests have transitioned to unittest.mock. Since we support Python 3.7 and greater, we can remove that requirement and pull them in line too.