### PR TITLE
Adopt requests new get_connection API

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,9 +43,15 @@ jobs:
         python-version: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12"]
         os: ["ubuntu-latest"]
         experimental: [false]
+        nox-session: ['']
+        include:
+          - python-version: "3.7"
+            os: "ubuntu-latest"
+            experimental: false
+            nox-session: "test-min-deps"
 
     runs-on: ${{ matrix.os }}
-    name: test-${{ matrix.python-version }}
+    name: test-${{ matrix.python-version }} ${{ matrix-nox-session }}
     continue-on-error: ${{ matrix.experimental }}
     steps:
       - name: Checkout repository
@@ -65,9 +71,10 @@ jobs:
         run: python -m pip install --upgrade nox
 
       - name: Run tests
-        run: "nox -rs test-${PYTHON_VERSION%-dev}"
+        run: nox -s ${NOX_SESSION:-test-$PYTHON_VERSION}
         env:
           PYTHON_VERSION: ${{ matrix.python-version }}
+          NOX_SESSION: ${{ matrix.nox-session }}
           # Required for development versions of Python
           AIOHTTP_NO_EXTENSIONS: 1
           FROZENLIST_NO_EXTENSIONS: 1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,7 +45,7 @@ jobs:
         experimental: [false]
         nox-session: ['']
         include:
-          - python-version: "3.7"
+          - python-version: "3.8"
             os: "ubuntu-latest"
             experimental: false
             nox-session: "test-min-deps"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,7 +51,7 @@ jobs:
             nox-session: "test-min-deps"
 
     runs-on: ${{ matrix.os }}
-    name: test-${{ matrix.python-version }} ${{ matrix-nox-session }}
+    name: test-${{ matrix.python-version }} ${{ matrix.nox-session }}
     continue-on-error: ${{ matrix.experimental }}
     steps:
       - name: Checkout repository

--- a/elastic_transport/_node/_http_requests.py
+++ b/elastic_transport/_node/_http_requests.py
@@ -170,7 +170,7 @@ class RequestsHttpNode(BaseNode):
         # Preload the HTTPConnectionPool so initialization issues
         # are raised here instead of in perform_request()
         if hasattr(adapter, "get_connection_with_tls_context"):
-            request = requests.Request(url=self.base_url)
+            request = requests.Request(method="GET", url=self.base_url)
             prepared_request = self.session.prepare_request(request)
             adapter.get_connection_with_tls_context(
                 prepared_request, verify=self.session.verify

--- a/elastic_transport/_node/_http_requests.py
+++ b/elastic_transport/_node/_http_requests.py
@@ -170,14 +170,16 @@ class RequestsHttpNode(BaseNode):
         # Preload the HTTPConnectionPool so initialization issues
         # are raised here instead of in perform_request()
         if hasattr(adapter, "get_connection_with_tls_context"):
+            request = requests.Request(url=self.base_url)
+            prepared_request = self.session.prepare_request(request)
             adapter.get_connection_with_tls_context(
-                requests.Request(url=self.base_url), verify=self.session.verify
+                prepared_request, verify=self.session.verify
             )
         else:
             # elastic-transport is not vulnerable to CVE-2024-35195 because it uses
             # requests.Session and an SSLContext without using the verify parameter.
             # We should remove this branch when requiring requests 2.32 or later.
-            adapter.get_connection(self.base_url)  # type: ignore [no-untyped-call]
+            adapter.get_connection(self.base_url)
 
         self.session.mount(prefix=f"{self.scheme}://", adapter=adapter)
 

--- a/noxfile.py
+++ b/noxfile.py
@@ -71,7 +71,7 @@ def test(session):
     session.run("coverage", "report", "-m")
 
 
-@nox.session(name="test-min-deps", python="3.7")
+@nox.session(name="test-min-deps", python="3.8")
 def test_min_deps(session):
     session.install("-r", "requirements-min.txt", ".[develop]", silent=False)
     session.run(

--- a/noxfile.py
+++ b/noxfile.py
@@ -71,6 +71,18 @@ def test(session):
     session.run("coverage", "report", "-m")
 
 
+@nox.session(name="test-min-deps", python="3.7")
+def test_min_deps(session):
+    session.install("-r", "requirements-min.txt", ".[develop]", silent=False)
+    session.run(
+        "pytest",
+        "--cov=elastic_transport",
+        *(session.posargs or ("tests/",)),
+        env={"PYTHONWARNINGS": "always::DeprecationWarning"},
+    )
+    session.run("coverage", "report", "-m")
+
+
 @nox.session(python="3")
 def docs(session):
     session.install(".[develop]")

--- a/requirements-min.txt
+++ b/requirements-min.txt
@@ -1,0 +1,4 @@
+requests==2.26.0
+urllib3==1.26.2
+aiohttp==3.8.0
+httpx==0.27.0


### PR DESCRIPTION
To fix a security vulnerability, requests removed `HTTPAdapter.get_connection()` in favor of `HTTPAdapter.get_connection_with_tls_context()`. This breaks the transport and client when using requests 2.32 or later, as the transport directly calls the removed API. This pull request fixes the issue.

See https://github.com/psf/requests/pull/6710 for more details.