### PR TITLE
Test minimum dependencies in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,6 +43,12 @@ jobs:
         python-version: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12"]
         os: ["ubuntu-latest"]
         experimental: [false]
+        nox-session: ['']
+        include:
+          - python-version: "3.7"
+            os: "ubuntu-latest"
+            experimental: false
+            nox-session: "test-min-deps"
 
     runs-on: ${{ matrix.os }}
     name: test-${{ matrix.python-version }}
@@ -65,9 +71,10 @@ jobs:
         run: python -m pip install --upgrade nox
 
       - name: Run tests
-        run: "nox -rs test-${PYTHON_VERSION%-dev}"
+        run: nox -s ${NOX_SESSION:-test-$PYTHON_VERSION}
         env:
           PYTHON_VERSION: ${{ matrix.python-version }}
+          NOX_SESSION: ${{ matrix.nox-session }}
           # Required for development versions of Python
           AIOHTTP_NO_EXTENSIONS: 1
           FROZENLIST_NO_EXTENSIONS: 1

--- a/noxfile.py
+++ b/noxfile.py
@@ -71,6 +71,18 @@ def test(session):
     session.run("coverage", "report", "-m")
 
 
+@nox.session(name="test-min-deps", python="3.7")
+def test_min_deps(session):
+    session.install("-r", "requirements-min.txt", ".[develop]", silent=False)
+    session.run(
+        "pytest",
+        "--cov=elastic_transport",
+        *(session.posargs or ("tests/",)),
+        env={"PYTHONWARNINGS": "always::DeprecationWarning"},
+    )
+    session.run("coverage", "report", "-m")
+
+
 @nox.session(python="3")
 def docs(session):
     session.install(".[develop]")

--- a/requirements-min.txt
+++ b/requirements-min.txt
@@ -1,0 +1,4 @@
+requests==2.26.0
+urllib3==1.26.2
+aiohttp==3.8.0
+httpx==0.27.0


### PR DESCRIPTION
This is the main blocker left in https://github.com/elastic/elastic-transport-python/pull/164.