### PR TITLE
Document response classes

### DIFF
--- a/docs/sphinx/conf.py
+++ b/docs/sphinx/conf.py
@@ -36,6 +36,7 @@ extensions = [
 ]
 
 pygments_style = "sphinx"
+pygments_dark_style = "monokai"
 
 templates_path = []
 exclude_patterns = []
@@ -44,5 +45,5 @@ html_static_path = []
 
 intersphinx_mapping = {
     "python": ("https://docs.python.org/3", None),
-    "requests": ("https://docs.python-requests.org/en/master", None),
+    "requests": ("https://docs.python-requests.org/en/latest", None),
 }

--- a/docs/sphinx/index.rst
+++ b/docs/sphinx/index.rst
@@ -6,6 +6,7 @@ API Reference
 
    installation
    nodes
+   responses
    exceptions
    logging
    transport

--- a/docs/sphinx/responses.rst
+++ b/docs/sphinx/responses.rst
@@ -1,0 +1,43 @@
+Responses
+=========
+
+.. py:currentmodule:: elastic_transport
+
+
+Response headers
+----------------
+
+.. autoclass:: elastic_transport::HttpHeaders
+   :members: freeze
+
+Metadata
+--------
+
+.. autoclass:: ApiResponseMeta
+   :members:
+
+Response classes
+----------------
+
+.. autoclass:: ApiResponse
+   :members:
+
+.. autoclass:: BinaryApiResponse
+   :members:
+   :show-inheritance:
+
+.. autoclass:: HeadApiResponse
+   :members:
+   :show-inheritance:
+
+.. autoclass:: ListApiResponse
+   :members:
+   :show-inheritance:
+
+.. autoclass:: ObjectApiResponse
+   :members:
+   :show-inheritance:
+
+.. autoclass:: TextApiResponse
+   :members:
+   :show-inheritance:

--- a/elastic_transport/_models.py
+++ b/elastic_transport/_models.py
@@ -68,7 +68,15 @@ except ImportError:
 
 
 class HttpHeaders(MutableMapping[str, str]):
-    """HTTP headers"""
+    """HTTP headers
+
+    Behaves like a Python dictionary. Can be used like this::
+
+      headers = HttpHeaders()
+      headers["foo"] = "bar"
+      headers["foo"] = "baz"
+      print(headers["foo"])  # prints "baz"
+    """
 
     __slots__ = ("_internal", "_frozen")
 
@@ -180,26 +188,24 @@ class HttpHeaders(MutableMapping[str, str]):
 
 @dataclass
 class ApiResponseMeta:
-    """Metadata that is returned from Transport.perform_request()"""
+    """Metadata that is returned from Transport.perform_request()
 
-    #: HTTP status code
+    :ivar int status: HTTP status code
+    :ivar str http_version: HTTP version being used
+    :ivar HttpHeaders headers: HTTP headers
+    :ivar float duration: Number of seconds from start of request to start of response
+    :ivar NodeConfig node: Node which handled the request
+    :ivar typing.Optional[str] mimetype: Mimetype to be used by the serializer to decode the raw response bytes.
+    """
+
     status: int
-
-    #: HTTP version being used
     http_version: str
-
-    #: HTTP headers
     headers: HttpHeaders
-
-    #: Number of seconds from start of request to start of response
     duration: float
-
-    #: Node which handled the request
     node: "NodeConfig"
 
     @property
     def mimetype(self) -> Optional[str]:
-        """Mimetype to be used by the serializer to decode the raw response bytes."""
         try:
             content_type = self.headers["content-type"]
             return content_type.partition(";")[0] or None


### PR DESCRIPTION
As part of answering to https://github.com/elastic/elasticsearch-py/issues/2606, I wanted to use Intersphinx mappings so that return types like "ObjectApiResponse" in [elasticsearch-py docs](https://elasticsearch-py.readthedocs.io/en/v8.14.0/api/indices.html#elasticsearch.client.IndicesClient.put_mapping) link to the transport docs. That way, users will be able to see that `response.meta.status` gives access to the status code. However, ObjectApiResponse is not in the Intersphinx data:

```bash
python -m sphinx.ext.intersphinx https://elastic-transport-python.readthedocs.io/en/latest/objects.inv
```

This pull requests fixes that, and it can be verified with:

```bash
python -m sphinx.ext.intersphinx docs/sphinx/_build/html/objects.inv
```