### PR TITLE
Add optional Arrow deserialization support

### DIFF
--- a/elastic_transport/__init__.py
+++ b/elastic_transport/__init__.py
@@ -108,6 +108,13 @@ try:
 except ImportError:
     pass
 
+try:
+    from elastic_transport._serializer import PyArrowSerializer  # noqa: F401
+
+    __all__.append("PyArrowSerializer")
+except ImportError:
+    pass
+
 _logger = logging.getLogger("elastic_transport")
 _logger.addHandler(logging.NullHandler())
 del _logger

--- a/noxfile.py
+++ b/noxfile.py
@@ -46,6 +46,7 @@ def lint(session):
         "mypy==1.7.1",
         "types-requests",
         "types-certifi",
+        "pyarrow-stubs",
     )
     # https://github.com/python/typeshed/issues/10786
     session.run(

--- a/requirements-min.txt
+++ b/requirements-min.txt
@@ -2,3 +2,4 @@ requests==2.26.0
 urllib3==1.26.2
 aiohttp==3.8.0
 httpx==0.27.0
+pyarrow==1.0.0

--- a/setup.py
+++ b/setup.py
@@ -70,6 +70,7 @@ setup(
             "opentelemetry-api",
             "opentelemetry-sdk",
             "orjson",
+            "pyarrow",
             # Override Read the Docs default (sphinx<2)
             "sphinx>2",
             "furo",

--- a/tests/test_package.py
+++ b/tests/test_package.py
@@ -29,6 +29,9 @@ def test__all__sorted(module):
     # Optional dependencies are added at the end
     if "OrjsonSerializer" in module_all:
         module_all.remove("OrjsonSerializer")
+    if "PyArrowSerializer" in module_all:
+        module_all.remove("PyArrowSerializer")
+
     assert module_all == sorted(module_all)
 
 


### PR DESCRIPTION
To be used with the Elasticsearch ES|QL Arrow support. I'm not converting to Pandas directly, because even if it's the most popular option today, I don't want to choose it over Polars, for example.