### PR TITLE
Remove raise_for_status, because it will prevent catching 404s.

### DIFF
--- a/elastic_transport/_node/_http_httpx.py
+++ b/elastic_transport/_node/_http_httpx.py
@@ -146,7 +146,6 @@ class HttpxAsyncHttpNode(BaseAsyncNode):
                     headers=dict(resolved_headers),
                     timeout=request_timeout,
                 )
-            resp.raise_for_status()
             response_body = resp.read()
             duration = time.perf_counter() - start
         except RERAISE_EXCEPTIONS + BUILTIN_EXCEPTIONS:


### PR DESCRIPTION
The `response.raise_for_status()` method raises HTTP exceptions for status codes. The Elasticsearch client relies for some functionality on HEAD requests to check whether resources exist. This is needed for (e.g.):
- `client.indices.exists()`
- `client.get()`

Raising the 404 error code as an HTTP exception will fail all downstream functionality. Not raising it as an HTTP exception should make it consistent again with how the Elasticsearch client is expecting the responses again. See https://github.com/elastic/elastic-transport-python/issues/174 for more details.