### PR TITLE
Fix test_unsupported_tls_versions with HTTPX

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -66,6 +66,8 @@ setup(
             "requests",
             "aiohttp",
             "httpx",
+            # https://github.com/encode/httpx/discussions/3214#discussioncomment-10830925
+            "httpcore<1.0.6",
             "respx",
             "opentelemetry-api",
             "opentelemetry-sdk",


### PR DESCRIPTION
The lint error is fixed in https://github.com/elastic/elastic-transport-python/pull/190.