### PR TITLE
Remove unneeded install requirement

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -52,7 +52,6 @@ setup(
     install_requires=[
         "urllib3>=1.26.2, <3",
         "certifi",
-        "importlib-metadata; python_version<'3.8'",
     ],
     python_requires=">=3.8",
     extras_require={


### PR DESCRIPTION
This library supports Python 3.8 or later.