### PR TITLE
Allow longer time for low performance architectures

### DIFF
--- a/tests/test_node_pool.py
+++ b/tests/test_node_pool.py
@@ -247,7 +247,7 @@ def test_threading_test(pool_size):
         def run(self) -> None:
             nonlocal pool
 
-            while time.time() < start + 2:
+            while time.time() < start + 5:
                 node = pool.get()
                 self.nodes_gotten += 1
                 if random.random() > 0.9:


### PR DESCRIPTION
I am a Fedora packager and recently observed that many tests were failing due to timeouts during the check stage. This issue is particularly noticeable on low-performance devices and current RISC-V hardware. The existing 2-second timeout is insufficient for these systems, leading to test failures.

To address this, I have adjusted the timeout duration from 2 seconds to 5 seconds. This change has been tested on the SG2042 (a RISC-V chip) and has shown to work well.