### PR TITLE
Fix use of SSLContext with sniffing

### DIFF
--- a/elastic_transport/_node/_urllib3_chain_certs.py
+++ b/elastic_transport/_node/_urllib3_chain_certs.py
@@ -108,7 +108,7 @@ class HTTPSConnectionPool(urllib3.HTTPSConnectionPool):
                 if sys.version_info >= (3, 13):
                     fingerprints = [
                         hash_func(cert).digest()
-                        for cert in conn.sock.get_verified_chain()
+                        for cert in conn.sock.get_verified_chain()  # type: ignore
                     ]
                 else:
                     # 'get_verified_chain()' and 'Certificate.public_bytes()' are private APIs

--- a/elastic_transport/_transport.py
+++ b/elastic_transport/_transport.py
@@ -540,13 +540,13 @@ def validate_sniffing_options(
 
 def warn_if_varying_node_config_options(node_configs: List[NodeConfig]) -> None:
     """Function which detects situations when sniffing may produce incorrect configs"""
-    exempt_attrs = {"host", "port", "connections_per_node", "_extras"}
+    exempt_attrs = {"host", "port", "connections_per_node", "_extras", "ssl_context"}
     match_attr_dict = None
     for node_config in node_configs:
         attr_dict = {
-            k: v
-            for k, v in dataclasses.asdict(node_config).items()
-            if k not in exempt_attrs
+            field.name: getattr(node_config, field.name)
+            for field in dataclasses.fields(node_config)
+            if field.name not in exempt_attrs
         }
         if match_attr_dict is None:
             match_attr_dict = attr_dict

--- a/setup.cfg
+++ b/setup.cfg
@@ -3,9 +3,6 @@ profile = black
 
 [tool:pytest]
 addopts = -vvv --cov-report=term-missing --cov=elastic_transport
-filterwarnings =
-    error
-    default:enable_cleanup_closed ignored.*:DeprecationWarning
 
 [coverage:report]
 omit = 

--- a/setup.cfg
+++ b/setup.cfg
@@ -3,6 +3,9 @@ profile = black
 
 [tool:pytest]
 addopts = -vvv --cov-report=term-missing --cov=elastic_transport
+filterwarnings =
+    error
+    default:enable_cleanup_closed ignored.*:DeprecationWarning
 
 [coverage:report]
 omit = 

--- a/tests/async_/test_async_transport.py
+++ b/tests/async_/test_async_transport.py
@@ -18,6 +18,7 @@
 import asyncio
 import random
 import re
+import ssl
 import sys
 import time
 import warnings
@@ -505,13 +506,17 @@ async def test_error_sniffing_callback_without_sniffing_enabled():
 @pytest.mark.asyncio
 async def test_heterogeneous_node_config_warning_with_sniffing():
     with warnings.catch_warnings(record=True) as w:
+        # SSLContext objects cannot be compared and are thus ignored
+        context = ssl.create_default_context()
         AsyncTransport(
             [
-                NodeConfig("http", "localhost", 80, path_prefix="/a"),
-                NodeConfig("http", "localhost", 81, path_prefix="/b"),
+                NodeConfig("https", "localhost", 80, path_prefix="/a", ssl_context=context),
+                NodeConfig("https", "localhost", 81, path_prefix="/b", ssl_context=context),
             ],
             sniff_on_start=True,
-            sniff_callback=lambda *_: [],
+            sniff_callback=lambda *_: [
+                NodeConfig("https", "localhost", 80, path_prefix="/a")
+            ],
         )
 
     assert len(w) == 1

--- a/tests/async_/test_async_transport.py
+++ b/tests/async_/test_async_transport.py
@@ -510,8 +510,12 @@ async def test_heterogeneous_node_config_warning_with_sniffing():
         context = ssl.create_default_context()
         AsyncTransport(
             [
-                NodeConfig("https", "localhost", 80, path_prefix="/a", ssl_context=context),
-                NodeConfig("https", "localhost", 81, path_prefix="/b", ssl_context=context),
+                NodeConfig(
+                    "https", "localhost", 80, path_prefix="/a", ssl_context=context
+                ),
+                NodeConfig(
+                    "https", "localhost", 81, path_prefix="/b", ssl_context=context
+                ),
             ],
             sniff_on_start=True,
             sniff_callback=lambda *_: [

--- a/tests/test_transport.py
+++ b/tests/test_transport.py
@@ -17,6 +17,7 @@
 
 import random
 import re
+import ssl
 import threading
 import time
 import warnings
@@ -537,14 +538,15 @@ def test_error_sniffing_callback_without_sniffing_enabled():
 
 def test_heterogeneous_node_config_warning_with_sniffing():
     with warnings.catch_warnings(record=True) as w:
+        context = ssl.create_default_context()
         Transport(
             [
-                NodeConfig("http", "localhost", 80, path_prefix="/a"),
-                NodeConfig("http", "localhost", 81, path_prefix="/b"),
+                NodeConfig("https", "localhost", 80, path_prefix="/a", ssl_context=context),
+                NodeConfig("https", "localhost", 81, path_prefix="/b", ssl_context=context),
             ],
             sniff_on_start=True,
             sniff_callback=lambda *_: [
-                NodeConfig("http", "localhost", 80, path_prefix="/a")
+                NodeConfig("https", "localhost", 80, path_prefix="/a")
             ],
         )
 

--- a/tests/test_transport.py
+++ b/tests/test_transport.py
@@ -541,8 +541,12 @@ def test_heterogeneous_node_config_warning_with_sniffing():
         context = ssl.create_default_context()
         Transport(
             [
-                NodeConfig("https", "localhost", 80, path_prefix="/a", ssl_context=context),
-                NodeConfig("https", "localhost", 81, path_prefix="/b", ssl_context=context),
+                NodeConfig(
+                    "https", "localhost", 80, path_prefix="/a", ssl_context=context
+                ),
+                NodeConfig(
+                    "https", "localhost", 81, path_prefix="/b", ssl_context=context
+                ),
             ],
             sniff_on_start=True,
             sniff_callback=lambda *_: [


### PR DESCRIPTION
Closes https://github.com/elastic/elasticsearch-py/issues/2731

When sniffing is enabled, `warn_if_varying_node_config_options` checks if all node configs use the same options besides host, port, and a few others. This is done using `dataclasses.asdict`, which will try to use the same mechanism as pickling to convert `SSLContext` objects to a dictionary. However, `SSLContext` objects cannot be pickled, and there's no good way to check that they are identical.

Instead, we choose to ignore `ssl_context`. We also have to stop using `asdict()` because it converts all keys, even those we don't need. Instead, we use the shallow copy workaround from the docs: https://docs.python.org/3/library/dataclasses.html#dataclasses.asdict.