### PR TITLE
Ensure compatibility with httpx v0.28.0+

### DIFF
--- a/elastic_transport/_node/_http_httpx.py
+++ b/elastic_transport/_node/_http_httpx.py
@@ -159,6 +159,7 @@ class HttpxAsyncHttpNode(BaseAsyncNode):
             elif isinstance(e, ssl.SSLError):
                 err = TlsError(str(e), errors=(e,))
             # Detect SSL errors for httpx v0.28.0+
+            # Needed until https://github.com/encode/httpx/issues/3350 is fixed
             elif isinstance(e, httpx.ConnectError) and e.__cause__:
                 context = e.__cause__.__context__
                 if isinstance(context, ssl.SSLError):

--- a/elastic_transport/_node/_http_httpx.py
+++ b/elastic_transport/_node/_http_httpx.py
@@ -158,6 +158,13 @@ class HttpxAsyncHttpNode(BaseAsyncNode):
                 )
             elif isinstance(e, ssl.SSLError):
                 err = TlsError(str(e), errors=(e,))
+            # Detect SSL errors for httpx v0.28.0+
+            elif isinstance(e, httpx.ConnectError) and e.__cause__:
+                context = e.__cause__.__context__
+                if isinstance(context, ssl.SSLError):
+                    err = TlsError(str(context), errors=(e,))
+                else:
+                    err = ConnectionError(str(e), errors=(e,))
             else:
                 err = ConnectionError(str(e), errors=(e,))
             self._log_request(

--- a/setup.py
+++ b/setup.py
@@ -65,8 +65,6 @@ setup(
             "requests",
             "aiohttp",
             "httpx",
-            # https://github.com/encode/httpx/discussions/3214#discussioncomment-10830925
-            "httpcore<1.0.6",
             "respx",
             "opentelemetry-api",
             "opentelemetry-sdk",


### PR DESCRIPTION
Hey, Arch Linux maintainer here :wave: 

SSL errors are thrown slightly different in httpx v0.28.0+ - Ensure these are caught and re-raised as TlsErrors.