### PR TITLE
Stop hiding cause of last exception

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -17,5 +17,5 @@ python:
         - develop
 
 sphinx:
-  configuration: docs/conf.py
+  configuration: docs/sphinx/conf.py
   fail_on_warning: true

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -17,4 +17,5 @@ python:
         - develop
 
 sphinx:
+  configuration: docs/conf.py
   fail_on_warning: true

--- a/elastic_transport/_exceptions.py
+++ b/elastic_transport/_exceptions.py
@@ -50,9 +50,6 @@ class TransportError(Exception):
             parts.append(f"errors={self.errors!r}")
         return "{}({})".format(self.__class__.__name__, ", ".join(parts))
 
-    def __str__(self) -> str:
-        return str(self.message)
-
 
 class SniffingError(TransportError):
     """Error that occurs during the sniffing of nodes"""
@@ -67,28 +64,13 @@ class SerializationError(TransportError):
 class ConnectionError(TransportError):
     """Error raised by the HTTP connection"""
 
-    def __str__(self) -> str:
-        if self.errors:
-            return f"Connection error caused by: {self.errors[0].__class__.__name__}({self.errors[0]})"
-        return "Connection error"
-
 
 class TlsError(ConnectionError):
     """Error raised by during the TLS handshake"""
 
-    def __str__(self) -> str:
-        if self.errors:
-            return f"TLS error caused by: {self.errors[0].__class__.__name__}({self.errors[0]})"
-        return "TLS error"
-
 
 class ConnectionTimeout(TransportError):
     """Connection timed out during an operation"""
-
-    def __str__(self) -> str:
-        if self.errors:
-            return f"Connection timeout caused by: {self.errors[0].__class__.__name__}({self.errors[0]})"
-        return "Connection timed out"
 
 
 class ApiError(Exception):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -15,6 +15,7 @@
 #  specific language governing permissions and limitations
 #  under the License.
 
+import copy
 import hashlib
 import logging
 import socket
@@ -40,7 +41,8 @@ class DummyNode(BaseNode):
     def perform_request(self, *args, **kwargs):
         self.calls.append((args, kwargs))
         if self.exception:
-            raise self.exception
+            # Raising the same exception can cause recursion errors when exceptions are linked together
+            raise copy.deepcopy(self.exception)
         meta = ApiResponseMeta(
             node=self.config,
             duration=0.0,
@@ -55,7 +57,8 @@ class AsyncDummyNode(DummyNode):
     async def perform_request(self, *args, **kwargs):
         self.calls.append((args, kwargs))
         if self.exception:
-            raise self.exception
+            # Raising the same exception can cause recursion errors when exceptions are linked together
+            raise copy.deepcopy(self.exception)
         meta = ApiResponseMeta(
             node=self.config,
             duration=0.0,


### PR DESCRIPTION
Closes #223

While this does not change any types, it does change the values returned by `str(e)` and `repr(e)`, so I would like to include this in 9.0 only, without backporting to 8.x.