### PR TITLE
Bring 8.17.1 release to main

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 8.17.1 (2025-03-12)
+
+* Ensure compatibility with httpx v0.28.0+ ([#222](https://github.com/elastic/elastic-transport-python/pull/222), contributed by Arch Linux maintainer @carlsmedstad)
+* Add missing NOTICE file ([#229](https://github.com/elastic/elastic-transport-python/pull/229), reported by Debian Maintainer @schoekek)
+
 ## 8.17.0 (2025-01-07)
 
 * Fix use of SSLContext with sniffing ([#199](https://github.com/elastic/elastic-transport-python/pull/199))

--- a/elastic_transport/_version.py
+++ b/elastic_transport/_version.py
@@ -15,4 +15,4 @@
 #  specific language governing permissions and limitations
 #  under the License.
 
-__version__ = "8.17.0"
+__version__ = "8.17.1"


### PR DESCRIPTION
# Backport

This will backport the following commits from `8.x` to `main`:
 - [Bring 8.17.1 release to parent (#241)](https://github.com/elastic/elastic-transport-python/pull/241)

<!--- Backport version: 9.6.6 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)