### PR TITLE
Use path_prefix to compute base_url in httpx

### DIFF
--- a/elastic_transport/_node/_http_httpx.py
+++ b/elastic_transport/_node/_http_httpx.py
@@ -102,7 +102,7 @@ class HttpxAsyncHttpNode(BaseAsyncNode):
                     ssl_context.load_cert_chain(config.client_cert)
 
         self.client = httpx.AsyncClient(
-            base_url=f"{config.scheme}://{config.host}:{config.port}",
+            base_url=f"{config.scheme}://{config.host}:{config.port}{config.path_prefix}",
             limits=httpx.Limits(max_connections=config.connections_per_node),
             verify=ssl_context or False,
             timeout=config.request_timeout,


### PR DESCRIPTION
Currently, the `path_prefix` configuration (i.e. the url path) of the ES host is removed by the httpx client. This PR adds it.

`path_prefix` is set by `client_utils.url_to_node_config` (https://github.com/elastic/elastic-transport-python/blob/main/elastic_transport/client_utils.py#L187). It is either `""` if the url path is empty or `"/"`, or the url path itself.

For example, if you configure host to be `http://localhost:9092/test` and run a search() query, you'll see an HTTP request sent to `http://localhost:9092/_search`, without the "test" prefix.

This is very useful when elastic endpoints are behind a reverse proxy with a specific path.