### PR TITLE
fix behaviour with pytest-asyncio 1.2.0

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -3,7 +3,7 @@ profile = black
 
 [tool:pytest]
 addopts = -vvv --cov-report=term-missing --cov=elastic_transport
-asyncio_default_fixture_loop_scope = "function"
+asyncio_default_fixture_loop_scope = function
 
 [coverage:report]
 omit = 


### PR DESCRIPTION
`pytest-asyncio` started throwing error on invalid `asyncio_default_fixture_loop_scope` entries in https://github.com/pytest-dev/pytest-asyncio/pull/1189