### PR TITLE
Add sync httpx node

### DIFF
--- a/docs/sphinx/installation.rst
+++ b/docs/sphinx/installation.rst
@@ -11,4 +11,4 @@ Install the ``requests`` package to use :class:`elastic_transport.RequestsHttpNo
 
 Install the ``aiohttp`` package to use :class:`elastic_transport.AiohttpHttpNode`.
 
-Install the ``httpx`` package to use :class:`elastic_transport.HttpxAsyncHttpNode`.
+Install the ``httpx`` package to use :class:`elastic_transport.HttpxHttpNode` or :class:`elastic_transport.HttpxAsyncHttpNode`.

--- a/docs/sphinx/nodes.rst
+++ b/docs/sphinx/nodes.rst
@@ -22,6 +22,9 @@ Node classes
 .. autoclass:: AiohttpHttpNode
    :members:
 
+.. autoclass:: HttpxHttpNode
+   :members:
+
 .. autoclass:: HttpxAsyncHttpNode
    :members:
 

--- a/elastic_transport/__init__.py
+++ b/elastic_transport/__init__.py
@@ -37,6 +37,7 @@ from ._node import (
     BaseAsyncNode,
     BaseNode,
     HttpxAsyncHttpNode,
+    HttpxHttpNode,
     RequestsHttpNode,
     Urllib3HttpNode,
 )
@@ -74,6 +75,7 @@ __all__ = [
     "HeadApiResponse",
     "HttpHeaders",
     "HttpxAsyncHttpNode",
+    "HttpxHttpNode",
     "JsonSerializer",
     "ListApiResponse",
     "NdjsonSerializer",

--- a/elastic_transport/_node/__init__.py
+++ b/elastic_transport/_node/__init__.py
@@ -18,7 +18,7 @@
 from ._base import BaseNode, NodeApiResponse
 from ._base_async import BaseAsyncNode
 from ._http_aiohttp import AiohttpHttpNode
-from ._http_httpx import HttpxAsyncHttpNode
+from ._http_httpx import HttpxAsyncHttpNode, HttpxHttpNode
 from ._http_requests import RequestsHttpNode
 from ._http_urllib3 import Urllib3HttpNode
 
@@ -29,5 +29,6 @@ __all__ = [
     "NodeApiResponse",
     "RequestsHttpNode",
     "Urllib3HttpNode",
+    "HttpxHttpNode",
     "HttpxAsyncHttpNode",
 ]

--- a/elastic_transport/_node/_http_httpx.py
+++ b/elastic_transport/_node/_http_httpx.py
@@ -30,6 +30,7 @@ from ._base import (
     BUILTIN_EXCEPTIONS,
     DEFAULT_CA_CERTS,
     RERAISE_EXCEPTIONS,
+    BaseNode,
     NodeApiResponse,
     ssl_context_from_node_config,
 )
@@ -43,6 +44,161 @@ try:
 except ImportError:
     _HTTPX_AVAILABLE = False
     _HTTPX_META_VERSION = ""
+
+
+class HttpxHttpNode(BaseNode):
+    _CLIENT_META_HTTP_CLIENT = ("hx", _HTTPX_META_VERSION)
+
+    def __init__(self, config: NodeConfig):
+        if not _HTTPX_AVAILABLE:  # pragma: nocover
+            raise ValueError("You must have 'httpx' installed to use HttpxNode")
+        super().__init__(config)
+
+        if config.ssl_assert_fingerprint:
+            raise ValueError(
+                "httpx does not support certificate pinning. https://github.com/encode/httpx/issues/761"
+            )
+
+        ssl_context: Union[ssl.SSLContext, Literal[False]] = False
+        if config.scheme == "https":
+            if config.ssl_context is not None:
+                ssl_context = ssl_context_from_node_config(config)
+            else:
+                ssl_context = ssl_context_from_node_config(config)
+
+                ca_certs = (
+                    DEFAULT_CA_CERTS if config.ca_certs is None else config.ca_certs
+                )
+                if config.verify_certs:
+                    if not ca_certs:
+                        raise ValueError(
+                            "Root certificates are missing for certificate "
+                            "validation. Either pass them in using the ca_certs parameter or "
+                            "install certifi to use it automatically."
+                        )
+                else:
+                    if config.ssl_show_warn:
+                        warnings.warn(
+                            f"Connecting to {self.base_url!r} using TLS with verify_certs=False is insecure",
+                            stacklevel=warn_stacklevel(),
+                            category=SecurityWarning,
+                        )
+
+                if ca_certs is not None:
+                    if os.path.isfile(ca_certs):
+                        ssl_context.load_verify_locations(cafile=ca_certs)
+                    elif os.path.isdir(ca_certs):
+                        ssl_context.load_verify_locations(capath=ca_certs)
+                    else:
+                        raise ValueError("ca_certs parameter is not a path")
+
+                # Use client_cert and client_key variables for SSL certificate configuration.
+                if config.client_cert and not os.path.isfile(config.client_cert):
+                    raise ValueError("client_cert is not a path to a file")
+                if config.client_key and not os.path.isfile(config.client_key):
+                    raise ValueError("client_key is not a path to a file")
+                if config.client_cert and config.client_key:
+                    ssl_context.load_cert_chain(config.client_cert, config.client_key)
+                elif config.client_cert:
+                    ssl_context.load_cert_chain(config.client_cert)
+
+        self.client = httpx.Client(
+            base_url=f"{config.scheme}://{config.host}:{config.port}",
+            limits=httpx.Limits(max_connections=config.connections_per_node),
+            verify=ssl_context or False,
+            timeout=config.request_timeout,
+        )
+
+    def perform_request(
+        self,
+        method: str,
+        target: str,
+        body: Optional[bytes] = None,
+        headers: Optional[HttpHeaders] = None,
+        request_timeout: Union[DefaultType, Optional[float]] = DEFAULT,
+    ) -> NodeApiResponse:
+        resolved_headers = self._headers.copy()
+        if headers:
+            resolved_headers.update(headers)
+
+        if body:
+            if self._http_compress:
+                resolved_body = gzip.compress(body)
+                resolved_headers["content-encoding"] = "gzip"
+            else:
+                resolved_body = body
+        else:
+            resolved_body = None
+
+        try:
+            start = time.perf_counter()
+            if request_timeout is DEFAULT:
+                resp = self.client.request(
+                    method,
+                    target,
+                    content=resolved_body,
+                    headers=dict(resolved_headers),
+                )
+            else:
+                resp = self.client.request(
+                    method,
+                    target,
+                    content=resolved_body,
+                    headers=dict(resolved_headers),
+                    timeout=request_timeout,
+                )
+            response_body = resp.read()
+            duration = time.perf_counter() - start
+        except RERAISE_EXCEPTIONS + BUILTIN_EXCEPTIONS:
+            raise
+        except Exception as e:
+            err: Exception
+            if isinstance(e, (TimeoutError, httpx.TimeoutException)):
+                err = ConnectionTimeout(
+                    "Connection timed out during request", errors=(e,)
+                )
+            elif isinstance(e, ssl.SSLError):
+                err = TlsError(str(e), errors=(e,))
+            # Detect SSL errors for httpx v0.28.0+
+            # Needed until https://github.com/encode/httpx/issues/3350 is fixed
+            elif isinstance(e, httpx.ConnectError) and e.__cause__:
+                context = e.__cause__.__context__
+                if isinstance(context, ssl.SSLError):
+                    err = TlsError(str(context), errors=(e,))
+                else:
+                    err = ConnectionError(str(e), errors=(e,))
+            else:
+                err = ConnectionError(str(e), errors=(e,))
+            self._log_request(
+                method=method,
+                target=target,
+                headers=resolved_headers,
+                body=body,
+                exception=err,
+            )
+            raise err from None
+
+        meta = ApiResponseMeta(
+            resp.status_code,
+            resp.http_version,
+            HttpHeaders(resp.headers),
+            duration,
+            self.config,
+        )
+
+        self._log_request(
+            method=method,
+            target=target,
+            headers=resolved_headers,
+            body=body,
+            meta=meta,
+            response=response_body,
+        )
+
+        return NodeApiResponse(meta, response_body)
+
+    def close(self) -> None:
+        self.client.close()
 
 
 class HttpxAsyncHttpNode(BaseAsyncNode):

--- a/elastic_transport/_node/_http_httpx.py
+++ b/elastic_transport/_node/_http_httpx.py
@@ -47,6 +47,10 @@ except ImportError:
 
 
 class HttpxHttpNode(BaseNode):
+    """
+    HTTP node using httpx.
+    """
+
     _CLIENT_META_HTTP_CLIENT = ("hx", _HTTPX_META_VERSION)
 
     def __init__(self, config: NodeConfig):
@@ -103,7 +107,7 @@ class HttpxHttpNode(BaseNode):
                     ssl_context.load_cert_chain(config.client_cert)
 
         self.client = httpx.Client(
-            base_url=f"{config.scheme}://{config.host}:{config.port}",
+            base_url=f"{config.scheme}://{config.host}:{config.port}{config.path_prefix}",
             limits=httpx.Limits(max_connections=config.connections_per_node),
             verify=ssl_context or False,
             timeout=config.request_timeout,
@@ -176,11 +180,11 @@ class HttpxHttpNode(BaseNode):
                 body=body,
                 exception=err,
             )
-            raise err from None
+            raise err from e
 
         meta = ApiResponseMeta(
             resp.status_code,
-            resp.http_version,
+            resp.http_version.lstrip("HTTP/"),
             HttpHeaders(resp.headers),
             duration,
             self.config,

--- a/elastic_transport/_transport.py
+++ b/elastic_transport/_transport.py
@@ -56,6 +56,7 @@ from ._node import (
     AiohttpHttpNode,
     BaseNode,
     HttpxAsyncHttpNode,
+    HttpxHttpNode,
     RequestsHttpNode,
     Urllib3HttpNode,
 )
@@ -70,6 +71,7 @@ NODE_CLASS_NAMES: Dict[str, Type[BaseNode]] = {
     "urllib3": Urllib3HttpNode,
     "requests": RequestsHttpNode,
     "aiohttp": AiohttpHttpNode,
+    "httpx": HttpxHttpNode,
     "httpxasync": HttpxAsyncHttpNode,
 }
 # These are HTTP status errors that shouldn't be considered

--- a/tests/async_/test_async_transport.py
+++ b/tests/async_/test_async_transport.py
@@ -322,7 +322,7 @@ async def test_node_class_as_string():
         AsyncTransport([NodeConfig("http", "localhost", 80)], node_class="huh?")
     assert str(e.value) == (
         "Unknown option for node_class: 'huh?'. "
-        "Available options are: 'aiohttp', 'httpxasync', 'requests', 'urllib3'"
+        "Available options are: 'aiohttp', 'httpx', 'httpxasync', 'requests', 'urllib3'"
     )
 
 

--- a/tests/node/test_base.py
+++ b/tests/node/test_base.py
@@ -20,6 +20,7 @@ import pytest
 from elastic_transport import (
     AiohttpHttpNode,
     HttpxAsyncHttpNode,
+    HttpxHttpNode,
     NodeConfig,
     RequestsHttpNode,
     Urllib3HttpNode,
@@ -28,7 +29,14 @@ from elastic_transport._node._base import ssl_context_from_node_config
 
 
 @pytest.mark.parametrize(
-    "node_cls", [Urllib3HttpNode, RequestsHttpNode, AiohttpHttpNode, HttpxAsyncHttpNode]
+    "node_cls",
+    [
+        Urllib3HttpNode,
+        RequestsHttpNode,
+        AiohttpHttpNode,
+        HttpxHttpNode,
+        HttpxAsyncHttpNode,
+    ],
 )
 def test_unknown_parameter(node_cls):
     with pytest.raises(TypeError):

--- a/tests/node/test_http_httpx.py
+++ b/tests/node/test_http_httpx.py
@@ -22,19 +22,19 @@ import warnings
 import pytest
 import respx
 
-from elastic_transport import HttpxAsyncHttpNode, NodeConfig
+from elastic_transport import HttpxAsyncHttpNode, HttpxHttpNode, NodeConfig
 from elastic_transport._node._base import DEFAULT_USER_AGENT
 
 
-def create_node(node_config: NodeConfig):
-    return HttpxAsyncHttpNode(node_config)
+def create_sync_node(node_config: NodeConfig):
+    return HttpxHttpNode(node_config)
 
 
-class TestHttpxAsyncNodeCreation:
+class TestHttpxNodeCreation:
     def test_ssl_context(self):
         ssl_context = ssl.create_default_context()
         with warnings.catch_warnings(record=True) as w:
-            node = create_node(
+            node = create_sync_node(
                 NodeConfig(
                     scheme="https",
                     host="localhost",
@@ -47,7 +47,9 @@ class TestHttpxAsyncNodeCreation:
 
     def test_uses_https_if_verify_certs_is_off(self):
         with warnings.catch_warnings(record=True) as w:
-            _ = create_node(NodeConfig("https", "localhost", 443, verify_certs=False))
+            _ = create_sync_node(
+                NodeConfig("https", "localhost", 443, verify_certs=False)
+            )
         assert (
             str(w[0].message)
             == "Connecting to 'https://localhost:443' using TLS with verify_certs=False is insecure"
@@ -55,7 +57,7 @@ class TestHttpxAsyncNodeCreation:
 
     def test_no_warn_when_uses_https_if_verify_certs_is_off(self):
         with warnings.catch_warnings(record=True) as w:
-            _ = create_node(
+            _ = create_sync_node(
                 NodeConfig(
                     "https",
                     "localhost",
@@ -68,7 +70,125 @@ class TestHttpxAsyncNodeCreation:
 
     def test_ca_certs_with_verify_ssl_false_raises_error(self):
         with pytest.raises(ValueError) as exc:
-            create_node(
+            create_sync_node(
+                NodeConfig(
+                    "https",
+                    "localhost",
+                    443,
+                    ca_certs="/ca/certs",
+                    verify_certs=False,
+                )
+            )
+            assert (
+                str(exc.value) == "You cannot use 'ca_certs' when 'verify_certs=False'"
+            )
+
+
+class TestHttpxNode:
+    @respx.mock
+    def test_simple_request(self):
+        node = create_sync_node(NodeConfig(scheme="http", host="localhost", port=80))
+        respx.get("http://localhost/index")
+        node.perform_request("GET", "/index", b"hello world", headers={"key": "value"})
+        request = respx.calls.last.request
+        assert request.content == b"hello world"
+        assert {
+            "key": "value",
+            "connection": "keep-alive",
+            "user-agent": DEFAULT_USER_AGENT,
+        }.items() <= request.headers.items()
+
+    @respx.mock
+    def test_compression(self):
+        node = create_sync_node(
+            NodeConfig(scheme="http", host="localhost", port=80, http_compress=True)
+        )
+        respx.get("http://localhost/index")
+        node.perform_request("GET", "/index", b"hello world")
+        request = respx.calls.last.request
+        assert gzip.decompress(request.content) == b"hello world"
+        assert {"content-encoding": "gzip"}.items() <= request.headers.items()
+
+    @respx.mock
+    def test_default_timeout(self):
+        node = create_sync_node(
+            NodeConfig(scheme="http", host="localhost", port=80, request_timeout=10)
+        )
+        respx.get("http://localhost/index")
+        node.perform_request("GET", "/index", b"hello world")
+        request = respx.calls.last.request
+        assert request.extensions["timeout"]["connect"] == 10
+
+    @respx.mock
+    def test_overwritten_timeout(self):
+        node = create_sync_node(
+            NodeConfig(scheme="http", host="localhost", port=80, request_timeout=10)
+        )
+        respx.get("http://localhost/index")
+        node.perform_request("GET", "/index", b"hello world", request_timeout=15)
+        request = respx.calls.last.request
+        assert request.extensions["timeout"]["connect"] == 15
+
+    @respx.mock
+    def test_merge_headers(self):
+        node = create_sync_node(
+            NodeConfig("http", "localhost", 80, headers={"h1": "v1", "h2": "v2"})
+        )
+        respx.get("http://localhost/index")
+        node.perform_request(
+            "GET", "/index", b"hello world", headers={"h2": "v2p", "h3": "v3"}
+        )
+        request = respx.calls.last.request
+        assert request.headers["h1"] == "v1"
+        assert request.headers["h2"] == "v2p"
+        assert request.headers["h3"] == "v3"
+
+
+def create_async_node(node_config: NodeConfig):
+    return HttpxAsyncHttpNode(node_config)
+
+
+class TestHttpxAsyncNodeCreation:
+    def test_ssl_context(self):
+        ssl_context = ssl.create_default_context()
+        with warnings.catch_warnings(record=True) as w:
+            node = create_async_node(
+                NodeConfig(
+                    scheme="https",
+                    host="localhost",
+                    port=80,
+                    ssl_context=ssl_context,
+                )
+            )
+        assert node.client._transport._pool._ssl_context is ssl_context
+        assert len(w) == 0
+
+    def test_uses_https_if_verify_certs_is_off(self):
+        with warnings.catch_warnings(record=True) as w:
+            _ = create_async_node(
+                NodeConfig("https", "localhost", 443, verify_certs=False)
+            )
+        assert (
+            str(w[0].message)
+            == "Connecting to 'https://localhost:443' using TLS with verify_certs=False is insecure"
+        )
+
+    def test_no_warn_when_uses_https_if_verify_certs_is_off(self):
+        with warnings.catch_warnings(record=True) as w:
+            _ = create_async_node(
+                NodeConfig(
+                    "https",
+                    "localhost",
+                    443,
+                    verify_certs=False,
+                    ssl_show_warn=False,
+                )
+            )
+        assert 0 == len(w)
+
+    def test_ca_certs_with_verify_ssl_false_raises_error(self):
+        with pytest.raises(ValueError) as exc:
+            create_async_node(
                 NodeConfig(
                     "https",
                     "localhost",
@@ -98,7 +218,7 @@ class TestHttpxAsyncNodeCreation:
 class TestHttpxAsyncNode:
     @respx.mock
     async def test_simple_request(self):
-        node = create_node(NodeConfig(scheme="http", host="localhost", port=80))
+        node = create_async_node(NodeConfig(scheme="http", host="localhost", port=80))
         respx.get("http://localhost/index")
         await node.perform_request(
             "GET", "/index", b"hello world", headers={"key": "value"}
@@ -113,7 +233,7 @@ class TestHttpxAsyncNode:
 
     @respx.mock
     async def test_compression(self):
-        node = create_node(
+        node = create_async_node(
             NodeConfig(scheme="http", host="localhost", port=80, http_compress=True)
         )
         respx.get("http://localhost/index")
@@ -124,7 +244,7 @@ class TestHttpxAsyncNode:
 
     @respx.mock
     async def test_default_timeout(self):
-        node = create_node(
+        node = create_async_node(
             NodeConfig(scheme="http", host="localhost", port=80, request_timeout=10)
         )
         respx.get("http://localhost/index")
@@ -134,7 +254,7 @@ class TestHttpxAsyncNode:
 
     @respx.mock
     async def test_overwritten_timeout(self):
-        node = create_node(
+        node = create_async_node(
             NodeConfig(scheme="http", host="localhost", port=80, request_timeout=10)
         )
         respx.get("http://localhost/index")
@@ -144,7 +264,7 @@ class TestHttpxAsyncNode:
 
     @respx.mock
     async def test_merge_headers(self):
-        node = create_node(
+        node = create_async_node(
             NodeConfig("http", "localhost", 80, headers={"h1": "v1", "h2": "v2"})
         )
         respx.get("http://localhost/index")
@@ -157,9 +277,10 @@ class TestHttpxAsyncNode:
         assert request.headers["h3"] == "v3"
 
 
-def test_ssl_assert_fingerprint(cert_fingerprint, httpbin_secure):
+@pytest.mark.parametrize("node_class", [HttpxHttpNode, HttpxAsyncHttpNode])
+def test_ssl_assert_fingerprint(node_class, cert_fingerprint, httpbin_secure):
     with pytest.raises(ValueError, match="httpx does not support certificate pinning"):
-        HttpxAsyncHttpNode(
+        node_class(
             NodeConfig(
                 scheme="https",
                 host=httpbin_secure.host,

--- a/tests/node/test_http_httpx.py
+++ b/tests/node/test_http_httpx.py
@@ -83,6 +83,18 @@ class TestHttpxNodeCreation:
                 str(exc.value) == "You cannot use 'ca_certs' when 'verify_certs=False'"
             )
 
+    def test_path_prefix(self):
+        node = create_sync_node(
+            NodeConfig(
+                "http",
+                "localhost",
+                9200,
+                path_prefix="/test",
+            )
+        )
+        assert node.base_url == "http://localhost:9200/test"
+        assert node.client.base_url == "http://localhost:9200/test/"
+
 
 class TestHttpxNode:
     @respx.mock
@@ -202,7 +214,7 @@ class TestHttpxAsyncNodeCreation:
             )
 
     def test_path_prefix(self):
-        node = create_node(
+        node = create_async_node(
             NodeConfig(
                 "http",
                 "localhost",

--- a/tests/node/test_tls_versions.py
+++ b/tests/node/test_tls_versions.py
@@ -25,6 +25,7 @@ from elastic_transport import (
     AiohttpHttpNode,
     ConnectionError,
     HttpxAsyncHttpNode,
+    HttpxHttpNode,
     NodeConfig,
     RequestsHttpNode,
     TlsError,
@@ -39,7 +40,13 @@ TLSv1_2_URL = "https://tls-v1-2.badssl.com:1012"
 
 node_classes = pytest.mark.parametrize(
     "node_class",
-    [AiohttpHttpNode, Urllib3HttpNode, RequestsHttpNode, HttpxAsyncHttpNode],
+    [
+        AiohttpHttpNode,
+        Urllib3HttpNode,
+        RequestsHttpNode,
+        HttpxHttpNode,
+        HttpxAsyncHttpNode,
+    ],
 )
 
 supported_version_params = [

--- a/tests/test_httpbin.py
+++ b/tests/test_httpbin.py
@@ -25,7 +25,7 @@ from elastic_transport._node._base import DEFAULT_USER_AGENT
 from elastic_transport._transport import NODE_CLASS_NAMES
 
 
-@pytest.mark.parametrize("node_class", ["urllib3", "requests"])
+@pytest.mark.parametrize("node_class", ["urllib3", "requests", "httpx"])
 def test_simple_request(node_class, httpbin_node_config, httpbin):
     t = Transport([httpbin_node_config], node_class=node_class)
 
@@ -58,7 +58,7 @@ def test_simple_request(node_class, httpbin_node_config, httpbin):
     assert all(v == data["headers"][k] for k, v in request_headers.items())
 
 
-@pytest.mark.parametrize("node_class", ["urllib3", "requests"])
+@pytest.mark.parametrize("node_class", ["urllib3", "requests", "httpx"])
 def test_node(node_class, httpbin_node_config, httpbin):
     def new_node(**kwargs):
         return NODE_CLASS_NAMES[node_class](
@@ -70,8 +70,12 @@ def test_node(node_class, httpbin_node_config, httpbin):
     assert resp.status == 200
     parsed = parse_httpbin(data)
     assert parsed == {
-        "headers": {
-            "Accept-Encoding": "identity",
+        "headers": (
+            {"Accept": "*/*", "Accept-Encoding": "gzip, deflate, br"}
+            if node_class == "httpx"
+            else {"Accept-Encoding": "identity"}
+        )
+        | {
             "Connection": "keep-alive",
             "Host": f"{httpbin.host}:{httpbin.port}",
             "User-Agent": DEFAULT_USER_AGENT,
@@ -85,7 +89,8 @@ def test_node(node_class, httpbin_node_config, httpbin):
     assert resp.status == 200
     parsed = parse_httpbin(data)
     assert parsed == {
-        "headers": {
+        "headers": ({"Accept": "*/*"} if node_class == "httpx" else {})
+        | {
             "Accept-Encoding": "gzip",
             "Connection": "keep-alive",
             "Host": f"{httpbin.host}:{httpbin.port}",
@@ -99,7 +104,8 @@ def test_node(node_class, httpbin_node_config, httpbin):
     assert resp.status == 200
     parsed = parse_httpbin(data)
     assert parsed == {
-        "headers": {
+        "headers": ({"Accept": "*/*"} if node_class == "httpx" else {})
+        | {
             "Accept-Encoding": "gzip",
             "Content-Encoding": "gzip",
             "Content-Length": "33",
@@ -120,7 +126,8 @@ def test_node(node_class, httpbin_node_config, httpbin):
     assert resp.status == 200
     parsed = parse_httpbin(data)
     assert parsed == {
-        "headers": {
+        "headers": ({"Accept": "*/*"} if node_class == "httpx" else {})
+        | {
             "Accept-Encoding": "gzip",
             "Content-Encoding": "gzip",
             "Content-Length": "36",

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -25,6 +25,7 @@ from elastic_transport import (
     ConnectionError,
     HttpHeaders,
     HttpxAsyncHttpNode,
+    HttpxHttpNode,
     RequestsHttpNode,
     Urllib3HttpNode,
     debug_logging,
@@ -34,7 +35,13 @@ from elastic_transport._node._base import DEFAULT_USER_AGENT
 
 node_class = pytest.mark.parametrize(
     "node_class",
-    [Urllib3HttpNode, RequestsHttpNode, AiohttpHttpNode, HttpxAsyncHttpNode],
+    [
+        Urllib3HttpNode,
+        RequestsHttpNode,
+        AiohttpHttpNode,
+        HttpxAsyncHttpNode,
+        HttpxHttpNode,
+    ],
 )
 
 

--- a/tests/test_transport.py
+++ b/tests/test_transport.py
@@ -329,7 +329,7 @@ def test_node_class_as_string():
         Transport([NodeConfig("http", "localhost", 80)], node_class="huh?")
     assert str(e.value) == (
         "Unknown option for node_class: 'huh?'. "
-        "Available options are: 'aiohttp', 'httpxasync', 'requests', 'urllib3'"
+        "Available options are: 'aiohttp', 'httpx', 'httpxasync', 'requests', 'urllib3'"
     )
 
 
@@ -365,9 +365,9 @@ def test_transport_client_meta_node_class(node_class):
     assert (
         t._transport_client_meta[3] == t.node_pool.node_class._CLIENT_META_HTTP_CLIENT
     )
-    assert t._transport_client_meta[3][0] in ("ur", "rq")
+    assert t._transport_client_meta[3][0] in ("ur", "rq", "hx")
     assert re.match(
-        r"^et=[0-9.]+p?,py=[0-9.]+p?,t=[0-9.]+p?,(?:ur|rq)=[0-9.]+p?$",
+        r"^et=[0-9.]+p?,py=[0-9.]+p?,t=[0-9.]+p?,(?:ur|rq|hx)=[0-9.]+p?$",
         ",".join(f"{k}={v}" for k, v in t._transport_client_meta),
     )
 

--- a/tests/test_transport.py
+++ b/tests/test_transport.py
@@ -29,6 +29,7 @@ from elastic_transport import (
     AiohttpHttpNode,
     ConnectionError,
     ConnectionTimeout,
+    HttpxHttpNode,
     NodeConfig,
     RequestsHttpNode,
     SniffingError,
@@ -358,7 +359,7 @@ def test_head_response_false():
 
 @pytest.mark.parametrize(
     "node_class",
-    ["urllib3", "requests", Urllib3HttpNode, RequestsHttpNode],
+    ["urllib3", "requests", "httpx", Urllib3HttpNode, RequestsHttpNode, HttpxHttpNode],
 )
 def test_transport_client_meta_node_class(node_class):
     t = Transport([NodeConfig("http", "localhost", 80)], node_class=node_class)


### PR DESCRIPTION
This PR adds a synchronous node class that uses a`httpx`' `Client`. This would enable developers of downstream packages and applications to use either / both sync and async node classes using only `httpx`, instead of multiple Python HTTP packages.

The implementation is almost an exact copy of `HttpxAsyncHttpNode`, stripped of all `async` / `await` / `a*()`.