### PR TITLE
add default content type for empty requests 

### DIFF
--- a/elastic_transport/_async_transport.py
+++ b/elastic_transport/_async_transport.py
@@ -235,13 +235,11 @@ class AsyncTransport(Transport):
                 + resolve_default(client_meta, ())
             )
 
+        request_headers.setdefault("content-type", "application/json")
+
         # Serialize the request body to bytes based on the given mimetype.
         request_body: Optional[bytes]
         if body is not None:
-            if "content-type" not in request_headers:
-                raise ValueError(
-                    "Must provide a 'Content-Type' header to requests with bodies"
-                )
             request_body = self.serializers.dumps(
                 body, mimetype=request_headers["content-type"]
             )

--- a/elastic_transport/_transport.py
+++ b/elastic_transport/_transport.py
@@ -309,13 +309,11 @@ class Transport:
                 + resolve_default(client_meta, ())
             )
 
+        request_headers.setdefault("content-type", "application/json")
+
         # Serialize the request body to bytes based on the given mimetype.
         request_body: Optional[bytes]
         if body is not None:
-            if "content-type" not in request_headers:
-                raise ValueError(
-                    "Must provide a 'Content-Type' header to requests with bodies"
-                )
             request_body = self.serializers.dumps(
                 body, mimetype=request_headers["content-type"]
             )

--- a/tests/async_/test_async_transport.py
+++ b/tests/async_/test_async_transport.py
@@ -63,6 +63,7 @@ async def test_async_transport_httpbin(httpbin_node_config, httpbin):
     assert data["headers"] == {
         "Accept": "*/*",
         "Accept-Encoding": "gzip, deflate, br",
+        "Content-Type": "application/json",
         "User-Agent": DEFAULT_USER_AGENT,
         "Connection": "keep-alive",
         "Host": f"{httpbin.host}:{httpbin.port}",
@@ -93,7 +94,10 @@ async def test_request_with_custom_user_agent_header():
     assert {
         "body": None,
         "request_timeout": DEFAULT,
-        "headers": {"user-agent": "my-custom-value/1.2.3"},
+        "headers": {
+            "user-agent": "my-custom-value/1.2.3",
+            "content-type": "application/json",
+        },
     } == t.node_pool.get().calls[0][1]
 
 

--- a/tests/test_transport.py
+++ b/tests/test_transport.py
@@ -59,7 +59,10 @@ def test_request_with_custom_user_agent_header():
     assert {
         "body": None,
         "request_timeout": DEFAULT,
-        "headers": {"user-agent": "my-custom-value/1.2.3"},
+        "headers": {
+            "user-agent": "my-custom-value/1.2.3",
+            "content-type": "application/json",
+        },
     } == t.node_pool.get().calls[0][1]
 
 
@@ -402,7 +405,8 @@ def test_client_meta_header():
     assert 1 == len(calls)
     headers = calls[0][1]["headers"]
 
-    assert sorted(headers.keys()) == ["x-elastic-client-meta"]
+    assert sorted(headers.keys()) == ["content-type", "x-elastic-client-meta"]
+    assert headers["content-type"] == "application/json"
     assert re.match(
         r"^es=8\.0\.0p,py=[0-9.]+p?,t=[0-9.]+p?,dm=0\.0\.0p$",
         headers["x-elastic-client-meta"],
@@ -424,7 +428,8 @@ def test_client_meta_header_extras():
     assert 1 == len(calls)
     headers = calls[0][1]["headers"]
 
-    assert sorted(headers.keys()) == ["x-elastic-client-meta"]
+    assert sorted(headers.keys()) == ["content-type", "x-elastic-client-meta"]
+    assert headers["content-type"] == "application/json"
     assert re.match(
         r"^es=8\.0\.0p,py=[0-9.]+p?,t=[0-9.]+p?,dm=0\.0\.0p,h=s$",
         headers["x-elastic-client-meta"],


### PR DESCRIPTION
Closes https://github.com/elastic/elasticsearch-py/issues/3305
Elasticsearch 9.1+ will request requests with no content-types. 
Python transport layer only includes content-type when a request body is present but bodyless requests will have no content-type. 

Bodyless requests will now get `application/json` as default 