### PR TITLE
Remove default 10s request_timeout, set to None (no timeout) (Fixes #3424)

### DIFF
--- a/elastic_transport/_models.py
+++ b/elastic_transport/_models.py
@@ -238,7 +238,8 @@ class NodeConfig:
     connections_per_node: int = 10
 
     #: Number of seconds to wait before a request should timeout.
-    request_timeout: Optional[float] = 10.0
+    #: Set to ``None`` to wait indefinitely (no timeout).
+    request_timeout: Optional[float] = None
 
     #: Set to ``True`` to enable HTTP compression
     #: of request and response bodies via gzip.

--- a/elastic_transport/_node/_http_requests.py
+++ b/elastic_transport/_node/_http_requests.py
@@ -81,7 +81,7 @@ try:
                     pool_kwargs["cert_reqs"] = "CERT_NONE"
                     pool_kwargs["assert_hostname"] = False
 
-            super().init_poolmanager(connections, maxsize, block=block, **pool_kwargs)  # type: ignore [no-untyped-call]
+            super().init_poolmanager(connections, maxsize, block=block, **pool_kwargs)
             self.poolmanager.pool_classes_by_scheme["https"] = HTTPSConnectionPool
 
 except ImportError:  # pragma: nocover

--- a/elastic_transport/_node/_http_urllib3.py
+++ b/elastic_transport/_node/_http_urllib3.py
@@ -24,7 +24,7 @@ from typing import Any, Dict, Optional, Union
 try:
     from importlib import metadata
 except ImportError:
-    import importlib_metadata as metadata  # type: ignore[no-redef]
+    import importlib_metadata as metadata  # type: ignore[import-not-found, no-redef]
 
 import urllib3
 from urllib3.exceptions import ConnectTimeoutError, NewConnectionError, ReadTimeoutError

--- a/tests/node/test_http_aiohttp.py
+++ b/tests/node/test_http_aiohttp.py
@@ -78,7 +78,7 @@ class TestAiohttpHttpNode:
                 "user-agent": DEFAULT_USER_AGENT,
             },
             "timeout": aiohttp.ClientTimeout(
-                total=10,
+                total=0,
                 connect=None,
                 sock_read=None,
                 sock_connect=None,
@@ -111,7 +111,7 @@ class TestAiohttpHttpNode:
             "data": None,
             "headers": {"connection": "keep-alive", "user-agent": DEFAULT_USER_AGENT},
             "timeout": aiohttp.ClientTimeout(
-                total=10,
+                total=0,
                 connect=None,
                 sock_read=None,
                 sock_connect=None,

--- a/tests/node/test_http_requests.py
+++ b/tests/node/test_http_requests.py
@@ -156,6 +156,14 @@ class TestRequestsHttpNode:
 
         assert kwargs["timeout"] is None
 
+    def test_default_timeout_is_none(self):
+        node = self._get_mock_node(NodeConfig("http", "localhost", 80))
+        assert node.config.request_timeout is None
+
+        node.perform_request("GET", "/")
+        _, kwargs = node.session.send.call_args
+        assert kwargs["timeout"] is None
+
     def test_uses_https_if_verify_certs_is_off(self):
         with warnings.catch_warnings(record=True) as w:
             RequestsHttpNode(NodeConfig("https", "localhost", 443, verify_certs=False))

--- a/tests/node/test_http_urllib3.py
+++ b/tests/node/test_http_urllib3.py
@@ -153,6 +153,15 @@ class TestUrllib3HttpNode:
 
         assert kwargs["timeout"] == request_timeout
 
+    def test_default_timeout_is_none(self):
+        node = self._get_mock_node(NodeConfig("http", "localhost", 80))
+        assert node.config.request_timeout is None
+        assert node.pool.timeout.total is None
+
+        node.perform_request("GET", "/")
+        (_, _), kwargs = node.pool.urlopen.call_args
+        assert "timeout" not in kwargs
+
     def test_uses_https_if_verify_certs_is_off(self):
         with warnings.catch_warnings(record=True) as w:
             con = Urllib3HttpNode(

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -35,7 +35,7 @@ def test_empty_node_config():
         "http_compress": False,
         "path_prefix": "",
         "port": 9200,
-        "request_timeout": 10,
+        "request_timeout": None,
         "scheme": "https",
         "ssl_assert_fingerprint": None,
         "ssl_assert_hostname": None,


### PR DESCRIPTION
Fixes [#3424](https://github.com/elastic/elasticsearch-py/issues/3424): The default `request_timeout` of 10 seconds causes premature client-side disconnection in several real-world scenarios:

- `_bulk` requests with large payloads where indexing time alone exceeds 10 s
- Ingest pipelines with per-document cost (scripting, ML inference) that compounds across bulk items
- Serverless deployments where auto-scaling temporarily increases indexing latency

When the timeout fires, the caller has no per-item status and typically retries the full request, producing duplicates for any items already indexed.

This aligns with the JS client v9.x which also removed the default timeout.

## Changes

- `NodeConfig.request_timeout` default changed from `10.0` → `None` (wait indefinitely)
- All HTTP backends already handle `None` correctly:
  - `urllib3` and `requests`: `None` means no timeout natively
  - `httpx`: `None` means no timeout natively
  - `aiohttp`: maps `None` → `total=0`, which is its equivalent for no timeout
- Updated `test_models.py` to reflect the new default
- Fixed two aiohttp tests that had `total=10` hardcoded against the old default
- Added `test_default_timeout_is_none` to urllib3 and requests test suites

## Notes

Callers who set an explicit `request_timeout` on `NodeConfig` or per-request are completely unaffected.