### PR TITLE
escape percent characters in logging output

### DIFF
--- a/elastic_transport/_node/_base.py
+++ b/elastic_transport/_node/_base.py
@@ -240,6 +240,9 @@ class BaseNode:
                     log_args.extend((http_version, meta.status))
                 if meta.headers:
                     for header, value in sorted(meta.headers.items()):
+                        # escape any % characters in the value, to avoid them being
+                        # misinterpreted as a logging template placeholder
+                        value = value.replace("%", "%%")
                         lines.append(f"< {header.title()}: {value}")
                 if response:
                     try:


### PR DESCRIPTION
Since pytest 9.1.0 was released two days ago, two elasticsearch-py tests are failing. This new release changed how logging is captured, and their new capture solution raises exceptions on these tests because they have percent encoded characters. 

The issue is related to the Python logging module using C-style placeholders such as `%s`, `%d`, etc. When the logging text has, for example, a `%23` sequence to represent a percent-encoded `#` character, the logging module sees the `%` and thinks it is a template placeholder. This change escapes the `%`s in the logging text with `%%` so that they are rendered to the log correctly.