### PR TITLE
Escape percent characters in logged header names and request headers

### DIFF
--- a/elastic_transport/_node/_base.py
+++ b/elastic_transport/_node/_base.py
@@ -221,7 +221,9 @@ class BaseNode:
             log_args: List[Any] = [method, target, http_version]
             if headers:
                 for header, value in sorted(headers._dict_hide_auth().items()):
-                    lines.append(f"> {header.title()}: {value}")
+                    # escape any % characters in the whole line (name and value), to
+                    # avoid them being misinterpreted as logging template placeholders
+                    lines.append(f"> {header.title()}: {value}".replace("%", "%%"))
             if body is not None:
                 try:
                     body_encoded = body.decode("utf-8", "surrogatepass")
@@ -240,10 +242,10 @@ class BaseNode:
                     log_args.extend((http_version, meta.status))
                 if meta.headers:
                     for header, value in sorted(meta.headers.items()):
-                        # escape any % characters in the value, to avoid them being
-                        # misinterpreted as a logging template placeholder
-                        value = value.replace("%", "%%")
-                        lines.append(f"< {header.title()}: {value}")
+                        # escape any % characters in the whole line (name and value),
+                        # to avoid them being misinterpreted as logging template
+                        # placeholders
+                        lines.append(f"< {header.title()}: {value}".replace("%", "%%"))
                 if response:
                     try:
                         response_decoded = response.decode("utf-8", "surrogatepass")

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -22,10 +22,12 @@ import pytest
 
 from elastic_transport import (
     AiohttpHttpNode,
+    ApiResponseMeta,
     ConnectionError,
     HttpHeaders,
     HttpxAsyncHttpNode,
     HttpxHttpNode,
+    NodeConfig,
     RequestsHttpNode,
     Urllib3HttpNode,
     debug_logging,
@@ -180,3 +182,44 @@ async def test_debug_logging_error(httpbin_node_config, node_class, anyio_backen
     lines = stream.getvalue().split("\n")[:-3]
     assert "> HEAD /anything HTTP/?.?" in lines
     assert all(not line.startswith("<") for line in lines)
+
+
+def test_debug_logging_escapes_percent_in_headers():
+    # A '%' in a header name or value must not be treated as a logging template
+    # placeholder. '%' is a valid tchar in an HTTP field-name (RFC 9110), so a
+    # server (or caller) can supply one; before escaping, the trailing
+    # ``_logger.debug(fmt, *log_args)`` call raised inside logging while
+    # interpolating, dropping the whole request/response line.
+    node = Urllib3HttpNode(NodeConfig("http", "localhost", 9200))
+
+    stream = io.StringIO()
+    handler = logging.StreamHandler(stream)
+    logger = logging.getLogger("elastic_transport.node")
+    logger.addHandler(handler)
+    logger.setLevel(logging.DEBUG)
+    try:
+        meta = ApiResponseMeta(
+            status=200,
+            http_version="1.1",
+            # '%' in both a request header and a response header, in the name
+            # (not covered by escaping only the value) as well as the value.
+            headers=HttpHeaders({"X-%s%s-Trace": "100% ok"}),
+            duration=0.0,
+            node=node.config,
+        )
+        node._log_request(
+            "GET",
+            "/_search",
+            headers=HttpHeaders({"X-Opaque-Id": "req-%d"}),
+            body=None,
+            meta=meta,
+            response=b"{}",
+        )
+    finally:
+        logger.removeHandler(handler)
+
+    output = stream.getvalue()
+    # The literal text must round-trip verbatim (no logging error, no mangling).
+    assert "> X-Opaque-Id: req-%d" in output
+    assert "< X-%S%S-Trace: 100% ok" in output
+    assert "--- Logging error ---" not in output


### PR DESCRIPTION
Follow-up to #284. That PR escaped % in response header values before they're interpolated into the lazy %-style format string passed to _logger.debug(fmt, *log_args) in _log_request. The header name on the same line, and both the name and value of request headers, were still interpolated unescaped.

% is a valid tchar in an HTTP field-name (RFC 9110), so a response header named e.g. X-%s%s-Trace — or a caller-supplied request header like x-opaque-id: req-%d — still makes logging fail to render the request/response line at debug level. The error is swallowed by logging's handleError() (no crash, no information disclosure), so this is purely a debug-logging robustness fix, same class as #284.

Escapes the whole formatted line for both header loops so names are covered too, and adds a regression test for a header whose name contains % (fails before this change, passes after).